### PR TITLE
Extract admin functions

### DIFF
--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -759,7 +759,7 @@ pub fn encode_sections(sections: &[Vec<u8>]) -> Result<Vec<u8>, ()> {
     let mut out_data = Vec::with_capacity(out_len);
     for section in sections {
         let section_len = TryInto::<u32>::try_into(section.len())
-            .unwrap()
+            .map_err(|_| ())?
             .to_be_bytes();
         out_data.extend(section);
         out_data.extend_from_slice(&section_len);
@@ -1051,7 +1051,8 @@ pub mod host_functions {
                 let next = vm.db_next(*iterator_id as u32);
                 match next {
                     Ok((key, value)) => {
-                        let out_data = encode_sections(&[key, value]).unwrap();
+                        let out_data = encode_sections(&[key, value])
+                            .map_err(|_| WasmiVMError::InvalidValue)?;
                         let Tagged(value_pointer, _) =
                             passthrough_in::<WasmiVM<T>, ()>(vm, &out_data)?;
                         Ok(Some(RuntimeValue::I32(value_pointer as i32)))

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -321,6 +321,68 @@ where
     }
 }
 
+/// Clears the admin on the given contract, so no more migration possible.
+///
+/// Fails if the caller is not currently admin of the target contract.
+pub fn clear_admin<V: CosmwasmBaseVM>(
+    vm: &mut V,
+    sender: &Addr,
+    contract_addr: VmAddressOf<V>,
+) -> Result<Option<Binary>, VmErrorOf<V>> {
+    let CosmwasmContractMeta {
+        code_id,
+        admin,
+        label,
+    } = vm.contract_meta(contract_addr.clone())?;
+    ensure_admin::<V>(sender, admin)?;
+    vm.set_contract_meta(
+        contract_addr,
+        CosmwasmContractMeta {
+            code_id,
+            admin: None,
+            label,
+        },
+    )?;
+    Ok(None)
+}
+
+/// Set `new_admin` as the new admin of the contract `contract_addr`
+///
+/// Fails if the caller is not currently admin of the target contract.
+pub fn update_admin<V: CosmwasmBaseVM>(
+    vm: &mut V,
+    sender: &Addr,
+    contract_addr: VmAddressOf<V>,
+    new_admin: VmAddressOf<V>,
+) -> Result<Option<Binary>, VmErrorOf<V>> {
+    let CosmwasmContractMeta {
+        code_id,
+        admin,
+        label,
+    } = vm.contract_meta(contract_addr.clone())?;
+    ensure_admin::<V>(sender, admin)?;
+    vm.set_contract_meta(
+        contract_addr,
+        CosmwasmContractMeta {
+            code_id,
+            admin: Some(new_admin),
+            label,
+        },
+    )?;
+    Ok(None)
+}
+
+fn ensure_admin<V: CosmwasmBaseVM>(
+    sender: &Addr,
+    contract_admin: Option<VmAddressOf<V>>,
+) -> Result<(), VmErrorOf<V>> {
+    match contract_admin.map(Into::<Addr>::into) {
+        None => Err(SystemError::ImmutableCantMigrate.into()),
+        Some(admin) if admin == *sender => Ok(()),
+        _ => Err(SystemError::MustBeAdmin.into()),
+    }
+}
+
 fn sanitize_custom_attributes(
     attributes: &mut Vec<Attribute>,
     contract_address: String,
@@ -368,13 +430,6 @@ where
     log::debug!("SystemRun");
     let info: MessageInfo = vm.get();
     let env: Env = vm.get();
-    let ensure_admin = move |contract_admin: Option<VmAddressOf<V>>| -> Result<(), VmErrorOf<V>> {
-        match contract_admin.map(Into::<Addr>::into) {
-            None => Err(SystemError::ImmutableCantMigrate.into()),
-            Some(admin) if admin == info.sender => Ok(()),
-            _ => Err(SystemError::MustBeAdmin.into()),
-        }
-    };
     let output = cosmwasm_call::<I, V>(vm, message).map(Into::into);
 
     log::debug!("Output: {:?}", output);
@@ -488,7 +543,7 @@ where
                                 let vm_contract_addr = VmAddressOf::<V>::try_from(contract_addr)?;
                                 let CosmwasmContractMeta { admin, label, .. } =
                                     vm.contract_meta(vm_contract_addr.clone())?;
-                                ensure_admin(admin.clone())?;
+                                ensure_admin::<V>(&info.sender, admin.clone())?;
                                 vm.set_contract_meta(
                                     vm_contract_addr.clone(),
                                     CosmwasmContractMeta {
@@ -505,39 +560,11 @@ where
                             } => {
                                 let new_admin = new_admin.try_into()?;
                                 let vm_contract_addr = VmAddressOf::<V>::try_from(contract_addr)?;
-                                let CosmwasmContractMeta {
-                                    code_id,
-                                    admin,
-                                    label,
-                                } = vm.contract_meta(vm_contract_addr.clone())?;
-                                ensure_admin(admin)?;
-                                vm.set_contract_meta(
-                                    vm_contract_addr,
-                                    CosmwasmContractMeta {
-                                        code_id,
-                                        admin: Some(new_admin),
-                                        label,
-                                    },
-                                )?;
-                                Ok(None)
+                                update_admin::<V>(vm, &info.sender, vm_contract_addr, new_admin)
                             }
                             WasmMsg::ClearAdmin { contract_addr } => {
                                 let vm_contract_addr = VmAddressOf::<V>::try_from(contract_addr)?;
-                                let CosmwasmContractMeta {
-                                    code_id,
-                                    admin,
-                                    label,
-                                } = vm.contract_meta(vm_contract_addr.clone())?;
-                                ensure_admin(admin)?;
-                                vm.set_contract_meta(
-                                    vm_contract_addr,
-                                    CosmwasmContractMeta {
-                                        code_id,
-                                        admin: None,
-                                        label,
-                                    },
-                                )?;
-                                Ok(None)
+                                clear_admin::<V>(vm, &info.sender, vm_contract_addr)
                             }
                         },
                         CosmosMsg::Bank(bank_message) => match bank_message {


### PR DESCRIPTION
* `ClearAdmin` and `UpdateAdmin` functions are extracted from submessage handling.
* Removed `unwrap`s