### PR TITLE
IBC support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,14 +6,15 @@
         "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1656602417,
-        "narHash": "sha256-PJx1iVc3Gwd9Hh00OxCVFdmn9Exzo7Kd/5U6xysIl+4=",
+        "lastModified": 1667522439,
+        "narHash": "sha256-1tDYoumL5337T4BkC87iRXbAfeyeeOXa5WAbeP/ENqQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "c850d8c9352ae655b3ba1802889c9d80ae9b7ea6",
+        "rev": "b70e77d2e2d480a3a0bce3ecd2d981679588b23f",
         "type": "github"
       },
       "original": {
@@ -40,11 +41,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -55,11 +56,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -70,11 +71,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1656065134,
-        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -85,11 +86,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658145222,
-        "narHash": "sha256-aRsWjUyY09+q365KK8Sdd6EuPBfwaF9CZp0bGKFLrRc=",
+        "lastModified": 1667816927,
+        "narHash": "sha256-BjRdmoHVakdmnaY6BBGge+rpBEMhIjgXjXP4d2UvuO4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dab3ae9d8be645366d2dc9634cc172983885f9fc",
+        "rev": "ad83bff0088bcefd621fcf16b0db5d34f0cebf1c",
         "type": "github"
       },
       "original": {
@@ -103,10 +104,35 @@
         "crane": "crane",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay_2"
       }
     },
     "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1667487142,
+        "narHash": "sha256-bVuzLs1ZVggJAbJmEDVO9G6p8BH3HRaolK70KXvnWnU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "flake-utils": "flake-utils_3",
         "nixpkgs": [
@@ -114,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658112572,
-        "narHash": "sha256-L7OgumNmdM5b4yVhB7vVOtTR5Jw0uClpOpiW+T9MEGY=",
+        "lastModified": 1667789120,
+        "narHash": "sha256-Yid92tEY2CeS8VUiexjSw0hsjfQbRLbUCpqkdVLaEnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "aa8c2247998fe2f25030d1f509d8ed06970e5ab1",
+        "rev": "528499f67169671e931cf1ba63601803e58abd2a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,7 +7,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": [
+          "rust-overlay"
+        ]
       },
       "locked": {
         "lastModified": 1667522439,
@@ -104,35 +106,10 @@
         "crane": "crane",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay_2"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
-      "inputs": {
-        "flake-utils": [
-          "crane",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "crane",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1667487142,
-        "narHash": "sha256-bVuzLs1ZVggJAbJmEDVO9G6p8BH3HRaolK70KXvnWnU=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_2": {
       "inputs": {
         "flake-utils": "flake-utils_3",
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -22,10 +22,10 @@
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
         };
-      in with pkgs;
+      in
       let
         # Nightly rust used for wasm runtime compilation
-        rust-nightly = rust-bin.nightly.latest.default;
+        rust-nightly = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
         # Crane lib instantiated with current nixpkgs
         crane-lib = crane.mkLib pkgs;
@@ -36,10 +36,10 @@
         # Default args to crane
         common-args = {
           pname = "cosmwasm-vm";
-          src = lib.cleanSourceWith {
-            filter = lib.cleanSourceFilter;
-            src = lib.cleanSourceWith {
-              filter = nix-gitignore.gitignoreFilterPure (name: type: true)
+          src = pkgs.lib.cleanSourceWith {
+            filter = pkgs.lib.cleanSourceFilter;
+            src = pkgs.lib.cleanSourceWith {
+              filter = pkgs.nix-gitignore.gitignoreFilterPure (name: type: true)
                 [ ./.gitignore ] ./.;
               src = ./.;
             };
@@ -65,7 +65,7 @@
           });
           fmt = crane-nightly.cargoFmt common-args;
         };
-        devShell = mkShell {
+        devShell = pkgs.mkShell {
           buildInputs = [ rust-nightly ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
 
       in rec {
         packages.cosmwasm-vm = crane-nightly.buildPackage (common-cached-args // {
-          cargoTestCommand = "cargo test --features iterator";
+          cargoTestCommand = "cargo test";
         });
         packages.default = packages.cosmwasm-vm;
         checks = {

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-overlay.follows = "rust-overlay";
     };
   };
   outputs = { self, nixpkgs, crane, flake-utils, rust-overlay }:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,9 @@
+[toolchain]
+channel = "nightly-2022-08-09"
+components = [
+  "clippy",
+  "llvm-tools-preview",
+  "rust-analyzer",
+  "rustfmt",
+  "rust-src",
+]

--- a/std/Cargo.toml
+++ b/std/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = []
 iterator = []
+stargate = []
+ibc3 = []
 
 [dependencies]
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/std/src/lib.rs
+++ b/std/src/lib.rs
@@ -23,6 +23,24 @@ pub mod read_limits {
     pub const RESULT_QUERY: usize = 64 * MI;
     /// Max length (in bytes) of the query data from a query_chain call.
     pub const REQUEST_QUERY: usize = 64 * MI;
+    /// Max length (in bytes) of the result data from a ibc_channel_open call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_CHANNEL_OPEN: usize = 64 * MI;
+    /// Max length (in bytes) of the result data from a ibc_channel_connect call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_CHANNEL_CONNECT: usize = 64 * MI;
+    /// Max length (in bytes) of the result data from a ibc_channel_close call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_CHANNEL_CLOSE: usize = 64 * MI;
+    /// Max length (in bytes) of the result data from a ibc_packet_receive call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_PACKET_RECEIVE: usize = 64 * MI;
+    /// Max length (in bytes) of the result data from a ibc_packet_ack call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_PACKET_ACK: usize = 64 * MI;
+    /// Max length (in bytes) of the result data from a ibc_packet_timeout call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_PACKET_TIMEOUT: usize = 64 * MI;
 }
 
 /// The limits for the JSON deserialization.
@@ -46,14 +64,25 @@ pub mod deserialization_limits {
     pub const RESULT_QUERY: usize = 256 * KI;
     /// Max length (in bytes) of the query data from a query_chain call.
     pub const REQUEST_QUERY: usize = 256 * KI;
+    /// Max length (in bytes) of the result data from a ibc_channel_open call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_CHANNEL_OPEN: usize = 256 * KI;
+    /// Max length (in bytes) of the result data from a ibc_channel_connect call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_CHANNEL_CONNECT: usize = 256 * KI;
+    /// Max length (in bytes) of the result data from a ibc_channel_close call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_CHANNEL_CLOSE: usize = 256 * KI;
+    /// Max length (in bytes) of the result data from a ibc_packet_receive call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_PACKET_RECEIVE: usize = 256 * KI;
+    /// Max length (in bytes) of the result data from a ibc_packet_ack call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_PACKET_ACK: usize = 256 * KI;
+    /// Max length (in bytes) of the result data from a ibc_packet_timeout call.
+    #[cfg(feature = "stargate")]
+    pub const RESULT_IBC_PACKET_TIMEOUT: usize = 256 * KI;
 }
-
-pub type CosmwasmExecutionResult<T> = ContractResult<Response<T>>;
-pub type CosmwasmQueryResult = ContractResult<QueryResponse>;
-pub type CosmwasmReplyResult<T> = ContractResult<Response<T>>;
-pub type CosmwasmMigrateResult<T> = ContractResult<Response<T>>;
-
-pub type QueryResponse = Binary;
 
 pub trait DeserializeLimit {
     fn deserialize_limit() -> usize;
@@ -61,91 +90,6 @@ pub trait DeserializeLimit {
 
 pub trait ReadLimit {
     fn read_limit() -> usize;
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct ReplyResult<T>(pub CosmwasmExecutionResult<T>);
-impl<T> DeserializeLimit for ReplyResult<T> {
-    fn deserialize_limit() -> usize {
-        deserialization_limits::RESULT_REPLY
-    }
-}
-impl<T> ReadLimit for ReplyResult<T> {
-    fn read_limit() -> usize {
-        read_limits::RESULT_REPLY
-    }
-}
-impl<T> From<ReplyResult<T>> for ContractResult<Response<T>> {
-    fn from(ReplyResult(result): ReplyResult<T>) -> Self {
-        result
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct QueryResult(pub CosmwasmQueryResult);
-impl DeserializeLimit for QueryResult {
-    fn deserialize_limit() -> usize {
-        deserialization_limits::RESULT_QUERY
-    }
-}
-impl ReadLimit for QueryResult {
-    fn read_limit() -> usize {
-        read_limits::RESULT_QUERY
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct ExecuteResult<T>(pub CosmwasmExecutionResult<T>);
-impl<T> DeserializeLimit for ExecuteResult<T> {
-    fn deserialize_limit() -> usize {
-        deserialization_limits::RESULT_EXECUTE
-    }
-}
-impl<T> ReadLimit for ExecuteResult<T> {
-    fn read_limit() -> usize {
-        read_limits::RESULT_EXECUTE
-    }
-}
-impl<T> From<ExecuteResult<T>> for ContractResult<Response<T>> {
-    fn from(ExecuteResult(result): ExecuteResult<T>) -> Self {
-        result
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct InstantiateResult<T>(pub CosmwasmExecutionResult<T>);
-impl<T> DeserializeLimit for InstantiateResult<T> {
-    fn deserialize_limit() -> usize {
-        deserialization_limits::RESULT_INSTANTIATE
-    }
-}
-impl<T> ReadLimit for InstantiateResult<T> {
-    fn read_limit() -> usize {
-        read_limits::RESULT_INSTANTIATE
-    }
-}
-impl<T> From<InstantiateResult<T>> for ContractResult<Response<T>> {
-    fn from(InstantiateResult(result): InstantiateResult<T>) -> Self {
-        result
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-pub struct MigrateResult<T>(pub CosmwasmExecutionResult<T>);
-impl<T> DeserializeLimit for MigrateResult<T> {
-    fn deserialize_limit() -> usize {
-        deserialization_limits::RESULT_MIGRATE
-    }
-}
-impl<T> ReadLimit for MigrateResult<T> {
-    fn read_limit() -> usize {
-        read_limits::RESULT_MIGRATE
-    }
-}
-impl<T> From<MigrateResult<T>> for ContractResult<Response<T>> {
-    fn from(MigrateResult(result): MigrateResult<T>) -> Self {
-        result
-    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/vm-wasmi/Cargo.toml
+++ b/vm-wasmi/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-iterator = [ "cosmwasm-vm/iterator", "cosmwasm-minimal-std/iterator" ]
+default = [ "iterator", "stargate" ]
+iterator = [ "cosmwasm-vm/iterator" ]
+stargate = [ "cosmwasm-vm/stargate" ]
 
 [dependencies]
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -46,12 +46,11 @@ use core::{
 #[cfg(feature = "iterator")]
 use cosmwasm_minimal_std::Order;
 use cosmwasm_minimal_std::{
-    Addr, Binary, CanonicalAddr, Coin, ContractInfoResponse, CosmwasmQueryResult, Env, Event,
-    MessageInfo, SystemResult,
+    Addr, Binary, CanonicalAddr, Coin, ContractInfoResponse, Env, Event, MessageInfo, SystemResult,
 };
 use cosmwasm_vm::executor::{
     AllocateInput, AsFunctionName, CosmwasmCallInput, CosmwasmCallWithoutInfoInput,
-    DeallocateInput, ExecutorError, Unit,
+    CosmwasmQueryResult, DeallocateInput, ExecutorError, Unit, QueryResult,
 };
 use cosmwasm_vm::has::Has;
 use cosmwasm_vm::memory::{
@@ -458,7 +457,7 @@ where
         &mut self,
         address: Self::Address,
         message: &[u8],
-    ) -> Result<cosmwasm_minimal_std::QueryResult, Self::Error> {
+    ) -> Result<QueryResult, Self::Error> {
         self.charge(VmGas::QueryContinuation)?;
         self.0.query_continuation(address, message)
     }

--- a/vm-wasmi/src/lib.rs
+++ b/vm-wasmi/src/lib.rs
@@ -50,7 +50,7 @@ use cosmwasm_minimal_std::{
 };
 use cosmwasm_vm::executor::{
     AllocateInput, AsFunctionName, CosmwasmCallInput, CosmwasmCallWithoutInfoInput,
-    CosmwasmQueryResult, DeallocateInput, ExecutorError, Unit, QueryResult,
+    CosmwasmQueryResult, DeallocateInput, ExecutorError, QueryResult, Unit,
 };
 use cosmwasm_vm::has::Has;
 use cosmwasm_vm::memory::{

--- a/vm-wasmi/src/semantic.rs
+++ b/vm-wasmi/src/semantic.rs
@@ -10,7 +10,10 @@ use cosmwasm_minimal_std::{
     MessageInfo, Timestamp,
 };
 use cosmwasm_vm::{
-    executor::{cosmwasm_call, ExecuteInput, InstantiateInput, MigrateInput, QueryInput, InstantiateResult, CosmwasmExecutionResult, ExecuteResult},
+    executor::{
+        cosmwasm_call, CosmwasmExecutionResult, ExecuteInput, ExecuteResult, InstantiateInput,
+        InstantiateResult, MigrateInput, QueryInput,
+    },
     system::{
         cosmwasm_system_entrypoint, cosmwasm_system_run, CosmwasmCodeId, CosmwasmContractMeta,
     },

--- a/vm-wasmi/src/semantic.rs
+++ b/vm-wasmi/src/semantic.rs
@@ -8,7 +8,7 @@ use cosmwasm_minimal_std::Order;
 use cosmwasm_minimal_std::{
     Addr, Attribute, Binary, BlockInfo, Coin, ContractInfo, CosmwasmExecutionResult,
     CosmwasmQueryResult, Empty, Env, Event, ExecuteResult, InstantiateResult, MessageInfo,
-    QueryResult, Timestamp,
+    QueryResult, Timestamp, ibc::IbcTimeout,
 };
 use cosmwasm_vm::{
     executor::{cosmwasm_call, ExecuteInput, InstantiateInput, MigrateInput, QueryInput},
@@ -711,6 +711,32 @@ impl<'a> VMBase for SimpleWasmiVM<'a> {
         } else {
             Err(SimpleVMError::OutOfGas)
         }
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_transfer(
+        &mut self,
+        channel_id: String,
+        to_address: String,
+        amount: Coin,
+        timeout: IbcTimeout,
+    ) -> Result<(), Self::Error> {
+      todo!()
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_send_packet(
+        &mut self,
+        channel_id: String,
+        data: Binary,
+        timeout: IbcTimeout,
+    ) -> Result<(), Self::Error> {
+      todo!()
+    }
+
+    #[cfg(feature = "stargate")]
+    fn ibc_close_channel(&mut self, channel_id: String) -> Result<(), Self::Error> {
+      todo!()
     }
 }
 

--- a/vm-wasmi/src/semantic.rs
+++ b/vm-wasmi/src/semantic.rs
@@ -6,12 +6,11 @@ use core::{assert_matches::assert_matches, num::NonZeroU32, str::FromStr};
 #[cfg(feature = "iterator")]
 use cosmwasm_minimal_std::Order;
 use cosmwasm_minimal_std::{
-    Addr, Attribute, Binary, BlockInfo, Coin, ContractInfo, CosmwasmExecutionResult,
-    CosmwasmQueryResult, Empty, Env, Event, ExecuteResult, InstantiateResult, MessageInfo,
-    QueryResult, Timestamp, ibc::IbcTimeout,
+    ibc::IbcTimeout, Addr, Attribute, Binary, BlockInfo, Coin, ContractInfo, Empty, Env, Event,
+    MessageInfo, Timestamp,
 };
 use cosmwasm_vm::{
-    executor::{cosmwasm_call, ExecuteInput, InstantiateInput, MigrateInput, QueryInput},
+    executor::{cosmwasm_call, ExecuteInput, InstantiateInput, MigrateInput, QueryInput, InstantiateResult, CosmwasmExecutionResult, ExecuteResult},
     system::{
         cosmwasm_system_entrypoint, cosmwasm_system_run, CosmwasmCodeId, CosmwasmContractMeta,
     },
@@ -721,7 +720,7 @@ impl<'a> VMBase for SimpleWasmiVM<'a> {
         amount: Coin,
         timeout: IbcTimeout,
     ) -> Result<(), Self::Error> {
-      todo!()
+        todo!()
     }
 
     #[cfg(feature = "stargate")]
@@ -731,12 +730,12 @@ impl<'a> VMBase for SimpleWasmiVM<'a> {
         data: Binary,
         timeout: IbcTimeout,
     ) -> Result<(), Self::Error> {
-      todo!()
+        todo!()
     }
 
     #[cfg(feature = "stargate")]
     fn ibc_close_channel(&mut self, channel_id: String) -> Result<(), Self::Error> {
-      todo!()
+        todo!()
     }
 }
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-iterator = []
+default = [ "iterator", "stargate" ]
+iterator = [ "cosmwasm-minimal-std/iterator" ]
+stargate = [ "cosmwasm-minimal-std/stargate" ]
+ibc3 = [ "cosmwasm-minimal-std/ibc3" ]
 
 [dependencies]
 serde = { version = "1", default-features = false, features = ["derive"] }
@@ -12,7 +15,7 @@ serde_json = { version = "1", default-features = false, features = ["alloc"] }
 either = { version = "1.6", default-features = false }
 log = { version = "0.4", default-features = false }
 
-cosmwasm-minimal-std =  { path = "../std", default-features = false}
+cosmwasm-minimal-std =  { path = "../std", default-features = false }
 
 [dev-dependencies]
 wat = "1.0"

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -29,8 +29,8 @@
 use crate::{
     executor::{
         cosmwasm_call, AllocateInput, CosmwasmCallInput, CosmwasmCallWithoutInfoInput,
-        DeallocateInput, ExecuteInput, ExecutorError, HasInfo, InstantiateInput, MigrateInput,
-        ReplyInput, Unit,
+        CosmwasmQueryResult, DeallocateInput, ExecuteInput, ExecutorError, HasInfo,
+        InstantiateInput, MigrateInput, QueryResult, ReplyInput, Unit,
     },
     has::Has,
     input::{Input, OutputOf},
@@ -45,9 +45,9 @@ use alloc::{fmt::Display, format, string::String, vec, vec::Vec};
 use core::fmt::Debug;
 use cosmwasm_minimal_std::{
     ibc::IbcMsg, Addr, AllBalanceResponse, Attribute, BalanceResponse, BankMsg, BankQuery, Binary,
-    ContractResult, CosmosMsg, CosmwasmQueryResult, DeserializeLimit, Env, Event, MessageInfo,
-    QueryRequest, QueryResult, ReadLimit, Reply, ReplyOn, Response, SubMsg, SubMsgResponse,
-    SubMsgResult, SystemResult, WasmMsg, WasmQuery,
+    ContractResult, CosmosMsg, DeserializeLimit, Env, Event, MessageInfo, QueryRequest, ReadLimit,
+    Reply, ReplyOn, Response, SubMsg, SubMsgResponse, SubMsgResult, SystemResult, WasmMsg,
+    WasmQuery,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};

--- a/vm/src/system.rs
+++ b/vm/src/system.rs
@@ -44,7 +44,7 @@ use crate::{
 use alloc::{fmt::Display, format, string::String, vec, vec::Vec};
 use core::fmt::Debug;
 use cosmwasm_minimal_std::{
-    Addr, AllBalanceResponse, Attribute, BalanceResponse, BankMsg, BankQuery, Binary,
+    ibc::IbcMsg, Addr, AllBalanceResponse, Attribute, BalanceResponse, BankMsg, BankQuery, Binary,
     ContractResult, CosmosMsg, CosmwasmQueryResult, DeserializeLimit, Env, Event, MessageInfo,
     QueryRequest, QueryResult, ReadLimit, Reply, ReplyOn, Response, SubMsg, SubMsgResponse,
     SubMsgResult, SystemResult, WasmMsg, WasmQuery,
@@ -556,6 +556,29 @@ where
                             }
                             BankMsg::Burn { amount } => {
                                 vm.burn(&amount)?;
+                                Ok(None)
+                            }
+                        },
+                        CosmosMsg::Ibc(ibc_message) => match ibc_message {
+                            IbcMsg::Transfer {
+                                channel_id,
+                                to_address,
+                                amount,
+                                timeout,
+                            } => {
+                                vm.ibc_transfer(channel_id, to_address, amount, timeout)?;
+                                Ok(None)
+                            }
+                            IbcMsg::SendPacket {
+                                channel_id,
+                                data,
+                                timeout,
+                            } => {
+                                vm.ibc_send_packet(channel_id, data, timeout)?;
+                                Ok(None)
+                            }
+                            IbcMsg::CloseChannel { channel_id } => {
+                                vm.ibc_close_channel(channel_id)?;
                                 Ok(None)
                             }
                         },

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -32,7 +32,8 @@ use core::fmt::Debug;
 #[cfg(feature = "iterator")]
 use cosmwasm_minimal_std::Order;
 use cosmwasm_minimal_std::{
-    Binary, Coin, ContractInfoResponse, CosmwasmQueryResult, Event, QueryResult, SystemResult,
+    ibc::IbcTimeout, Binary, Coin, ContractInfoResponse, CosmwasmQueryResult, Event, QueryResult,
+    SystemResult,
 };
 
 use serde::de::DeserializeOwned;
@@ -106,6 +107,15 @@ pub enum VmGas {
     AddrCanonicalize,
     /// Cost of `addr_humanize`
     AddrHumanize,
+    #[cfg(feature = "stargate")]
+    /// Cost of `ibc_transfer`.
+    IbcTransfer,
+    #[cfg(feature = "stargate")]
+    /// Cost of `ibc_send_packet`.
+    IbcSendPacket,
+    #[cfg(feature = "stargate")]
+    /// Cost of `ibc_close_channel`.
+    IbcCloseChannel,
 }
 
 pub type VmInputOf<'a, T> = <T as VMBase>::Input<'a>;
@@ -160,7 +170,7 @@ pub trait VMBase {
     /// Possible errors raised by this VM.
     type Error;
 
-    // Get the contract metadata of the currently running contract.
+    /// Get the contract metadata of the currently running contract.
     fn running_contract_meta(&mut self) -> Result<Self::ContractMeta, Self::Error>;
 
     #[cfg(feature = "iterator")]
@@ -349,4 +359,27 @@ pub trait VMBase {
         signatures: &[&[u8]],
         public_keys: &[&[u8]],
     ) -> Result<bool, Self::Error>;
+
+    #[cfg(feature = "stargate")]
+    /// Transfer tokens over IBC.
+    fn ibc_transfer(
+        &mut self,
+        channel_id: String,
+        to_address: String,
+        amount: Coin,
+        timeout: IbcTimeout,
+    ) -> Result<(), Self::Error>;
+
+    #[cfg(feature = "stargate")]
+    /// Send a packet over IBC.
+    fn ibc_send_packet(
+        &mut self,
+        channel_id: String,
+        data: Binary,
+        timeout: IbcTimeout,
+    ) -> Result<(), Self::Error>;
+
+    #[cfg(feature = "stargate")]
+    /// Close an IBC channel.
+    fn ibc_close_channel(&mut self, channel_id: String) -> Result<(), Self::Error>;
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -26,14 +26,16 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-use crate::input::Input;
+use crate::{
+    executor::{CosmwasmQueryResult, QueryResult},
+    input::Input,
+};
 use alloc::{string::String, vec::Vec};
 use core::fmt::Debug;
 #[cfg(feature = "iterator")]
 use cosmwasm_minimal_std::Order;
 use cosmwasm_minimal_std::{
-    ibc::IbcTimeout, Binary, Coin, ContractInfoResponse, CosmwasmQueryResult, Event, QueryResult,
-    SystemResult,
+    ibc::IbcTimeout, Binary, Coin, ContractInfoResponse, Event, SystemResult,
 };
 
 use serde::de::DeserializeOwned;


### PR DESCRIPTION
- upgrade nix flake
- add `stargate` feature to enable IBC, as per the official VM
- add IBC messages
- add IBC host handlers
- add IBC gas metering abstraction
- implements IBC contract export calls
- add IBC calls limits
- move read/serialization limits from std to the vm