### PR TITLE
Add `CustomHandler` extension to `orchestrate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/docs/orchestrate/book
 /target
 /result

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +86,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bumpalo"
@@ -193,6 +205,8 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "bech32",
+ "bs58",
  "cosmwasm-crypto 1.1.6",
  "cosmwasm-std 1.1.6",
  "cosmwasm-vm",
@@ -1265,9 +1279,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -1630,9 +1644,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,14 +213,12 @@ dependencies = [
  "cosmwasm-vm-wasmi",
  "cw20 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cw20-base",
- "cw20-ics20",
  "env_logger 0.10.0",
  "hex",
  "log",
  "reqwest",
  "serde",
  "serde_json",
- "sha1",
  "sha2 0.10.6",
  "tokio",
  "wasm-instrument",
@@ -1554,17 +1552,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.5",
 ]
 
 [[package]]

--- a/docs/orchestrate/book.toml
+++ b/docs/orchestrate/book.toml
@@ -1,0 +1,7 @@
+[book]
+authors = ["ComposableFi Developers"]
+language = "en"
+multilingual = false
+src = "src"
+title = "Cosmwasm Orchestrate"
+

--- a/docs/orchestrate/src/README.md
+++ b/docs/orchestrate/src/README.md
@@ -4,11 +4,11 @@ CosmWasm Orchestrate is a tool for simulating and testing CosmWasm contracts on 
 
 ## Why use this?
 
-- **Complete simulation on a VM**: Your contracts do not run in a mock environment but actually in a complete VM, therefor your `CosmosMsg`'s, queries, submessages run properly.
+- **Complete simulation on a VM**: Your contracts do not run in a mock environment but actually in a complete VM, therefor your `CosmosMsg`'s, queries, and sub-messages run properly.
 
-- **IBC capable**: You don't need to spin up few chains to simulate IBC. You can just start few VM instances on our framework and run IBC contracts in-memory. This means that you will be able to test your IBC contracts really fast and correctly.
+- **IBC capable**: You don't need to spin up a few chains to simulate IBC. You can just start a few VM instances on our framework and run IBC contracts in memory. This means that you will be able to test your IBC contracts really fast and correctly.
     
-- **Easy to use**: Talking about VM's might sound frustrating but there is almost no setup necessary to run a test. Just provide the wasm contract that you want to test and call the entrypoint that you wanna test.
+- **Easy to use**: Talking about VMs might sound frustrating but there is almost no setup necessary to run a test. Just provide the wasm contract that you want to test and call the entry point that you wanna test.
 
 - **Flexible**: The framework is also very flexible and lets you define your own mechanism to handle custom messages, handle different address formats and even implement your own host functions and VM.
 
@@ -20,9 +20,9 @@ Enough talking and let's check out a very basic usage of our framework. Here you
 1. Fetch the wasm binary of the contract with the address `juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf`.
 2. Instantiate the `cw20-base` contract.
 3. Execute a transfer.
-4. Query the contract to see if transfer is done correctly.
+4. Query the contract to see if the transfer is done correctly.
 
-All in just few lines.
+All in just a few lines.
 
 ```rust
 // Fetch the wasm binary of the given contract from a remote chain.

--- a/docs/orchestrate/src/README.md
+++ b/docs/orchestrate/src/README.md
@@ -25,7 +25,7 @@ Enough talking and let's check out a very basic usage of our framework. Here you
 All in just few lines.
 
 ```rust
-/// Fetch the wasm binary of the given contract from a remote chain.
+// Fetch the wasm binary of the given contract from a remote chain.
 let code = CosmosFetcher::from_contract_addr(
     "https://juno-api.polkachu.com",
     "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
@@ -33,20 +33,20 @@ let code = CosmosFetcher::from_contract_addr(
 .await
 .unwrap();
 
-/// Generate a Juno compatible address
+// Generate a Juno compatible address
 let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
 
-/// Create a VM state by providing the codes that will be executed.
+// Create a VM state by providing the codes that will be executed.
 let mut state = StateBuilder::new().add_code(&code).build();
 
-let info = dummy_info(&sender);
+let info = info(&sender);
 
-/// Instantiate the cw20 contract
-let (contract, _) = <Api>::instantiate(
+// Instantiate the cw20 contract
+let (contract, _) = <JunoApi>::instantiate(
     &mut state,
     1,
     None,
-    dummy_block(),
+    block(),
     None,
     info.clone(),
     100_000_000,
@@ -64,10 +64,10 @@ let (contract, _) = <Api>::instantiate(
 )
 .unwrap();
 
-/// Transfer 10_000 PICA to the "receiver"
-let _ = <Api>::execute(
+// Transfer 10_000 PICA to the "receiver"
+let _ = <JunoApi>::execute(
     &mut state,
-    dummy_env(contract.into()),
+    env(&contract),
     info,
     100_000_000,
     ExecuteMsg::Transfer {
@@ -79,16 +79,17 @@ let _ = <Api>::execute(
 )
 .unwrap();
 
-/// Read the balance by using query. Note that the raw storage can be read here as well.
-let balance_response: BalanceResponse = 
-    Api::<Direct>::query(  
-      &mut state, 
-      dummy_env(contract.into()), 
-      QueryMsg::Balance {
-          address: Account::generate_from_seed::<JunoAddressHandler>("receiver")
-              .unwrap()
-              .into(),
-      }).unwrap();
+// Read the balance by using query. Note that the raw storage can be read here as well.
+let balance_response: BalanceResponse = JunoApi::<Direct>::query(
+    &mut state,
+    env(&contract),
+    QueryMsg::Balance {
+        address: Account::generate_from_seed::<JunoAddressHandler>("receiver")
+            .unwrap()
+            .into(),
+    },
+)
+.unwrap();
 
-assert_eq!(balance_response.balance, 10_000_u128.into());
+assert_eq!(Into::<u128>::into(balance_response.balance), 10_000_u128);
 ```

--- a/docs/orchestrate/src/README.md
+++ b/docs/orchestrate/src/README.md
@@ -1,0 +1,94 @@
+# Introduction
+
+CosmWasm Orchestrate is a tool for simulating and testing CosmWasm contracts on a virtual machine. Although this is the first version of the tool, it already provides a very close simulation experience to running your contracts on an actual chain.
+
+## Why use this?
+
+- **Complete simulation on a VM**: Your contracts do not run in a mock environment but actually in a complete VM, therefor your `CosmosMsg`'s, queries, submessages run properly.
+
+- **IBC capable**: You don't need to spin up few chains to simulate IBC. You can just start few VM instances on our framework and run IBC contracts in-memory. This means that you will be able to test your IBC contracts really fast and correctly.
+    
+- **Easy to use**: Talking about VM's might sound frustrating but there is almost no setup necessary to run a test. Just provide the wasm contract that you want to test and call the entrypoint that you wanna test.
+
+- **Flexible**: The framework is also very flexible and lets you define your own mechanism to handle custom messages, handle different address formats and even implement your own host functions and VM.
+
+
+## A Quick Example
+
+Enough talking and let's check out a very basic usage of our framework. Here you can see we execute a `cw20-base` contract. The exact steps are:
+
+1. Fetch the wasm binary of the contract with the address `juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf`.
+2. Instantiate the `cw20-base` contract.
+3. Execute a transfer.
+4. Query the contract to see if transfer is done correctly.
+
+All in just few lines.
+
+```rust
+/// Fetch the wasm binary of the given contract from a remote chain.
+let code = CosmosFetcher::from_contract_addr(
+    "https://juno-api.polkachu.com",
+    "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+)
+.await
+.unwrap();
+
+/// Generate a Juno compatible address
+let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
+
+/// Create a VM state by providing the codes that will be executed.
+let mut state = StateBuilder::new().add_code(&code).build();
+
+let info = dummy_info(&sender);
+
+/// Instantiate the cw20 contract
+let (contract, _) = <Api>::instantiate(
+    &mut state,
+    1,
+    None,
+    dummy_block(),
+    None,
+    info.clone(),
+    100_000_000,
+    InstantiateMsg {
+        name: "Picasso".into(),
+        symbol: "PICA".into(),
+        decimals: 12,
+        initial_balances: vec![Cw20Coin {
+            amount: 10000000_u128.into(),
+            address: sender.into(),
+        }],
+        mint: None,
+        marketing: None,
+    },
+)
+.unwrap();
+
+/// Transfer 10_000 PICA to the "receiver"
+let _ = <Api>::execute(
+    &mut state,
+    dummy_env(contract.into()),
+    info,
+    100_000_000,
+    ExecuteMsg::Transfer {
+        recipient: Account::generate_from_seed::<JunoAddressHandler>("receiver")
+            .unwrap()
+            .into(),
+        amount: 10_000_u128.into(),
+    },
+)
+.unwrap();
+
+/// Read the balance by using query. Note that the raw storage can be read here as well.
+let balance_response: BalanceResponse = 
+    Api::<Direct>::query(  
+      &mut state, 
+      dummy_env(contract.into()), 
+      QueryMsg::Balance {
+          address: Account::generate_from_seed::<JunoAddressHandler>("receiver")
+              .unwrap()
+              .into(),
+      }).unwrap();
+
+assert_eq!(balance_response.balance, 10_000_u128.into());
+```

--- a/docs/orchestrate/src/SUMMARY.md
+++ b/docs/orchestrate/src/SUMMARY.md
@@ -1,0 +1,10 @@
+# Summary
+
+[Introduction](./README.md)
+
+- [Concepts](./concepts/concepts.md)
+  - [Direct/Dispatch](./concepts/direct-dispatch.md)
+  - [Address Handlers](./concepts/address-handlers.md)
+  - [Custom Message Handler](./concepts/custom-handler.md)
+  
+- [Tutorial: Testing a DEX](./tutorial-dex.md)

--- a/docs/orchestrate/src/concepts/README.md
+++ b/docs/orchestrate/src/concepts/README.md
@@ -1,0 +1,6 @@
+# Concepts
+
+There are few concepts that is good for a user to know, these are:
+
+* **Direct vs Dispatch execution types**: Explains the behaviors of `Direct`
+and `Dispatch` execution types.

--- a/docs/orchestrate/src/concepts/address-handlers.md
+++ b/docs/orchestrate/src/concepts/address-handlers.md
@@ -1,0 +1,80 @@
+# Address Handlers
+
+Throughout this documentation, you see that we always use `JunoApi`. But there are 
+few other API's as well like `WasmApi`, `SubstrateApi`, etc. The only difference between
+this API's is how they handle the address generation, validation and canonicalization.
+
+For example, Cosmos API's like `JunoApi` or `WasmApi` uses `Bech32` encoding and `JunoApi` uses
+`juno` as prefix and `WasmApi` uses `wasm` as prefix.
+
+## Creating your own Cosmos address handler
+
+Cosmos address handlers are implementing the `CosmosAddressHandler` trait which
+handles the `Bech32` stuff under the hood. The only thing that you want to specify
+is the `PREFIX` constant which is the prefix value in `Bech32` encoding.
+
+Let's create an Address Handler for `CoolChain` where the prefix is `cool`:
+
+```rust
+pub struct CoolAddressHandler;
+
+impl CosmosAddressHandler for CoolAddressHandler {
+    const PREFIX: &'static str = "cool";
+}
+```
+
+For ease of use, you can also define this API:
+
+```rust
+pub type CoolApi<'a, E = Dispatch> = Api<
+    'a,
+    E,
+    CoolAddressHandler,
+    State<(), CoolAddressHandler>,
+    Context<'a, (), CoolAddressHandler>,
+>;
+```
+
+From now on, you can generate account addresses by using `CoolAddressHandler`:
+
+```rust
+Account::generate_from_seed::<CoolAddressHandler>("sender").unwrap();
+```
+
+And you will use the `CoolApi` for API calls:
+
+```rust
+<CoolApi>::instantiate(..);
+```
+
+## Implementing an address handler from scratch
+
+You can also implement an address handler from scratch by implementing `AddressHandler` trait.
+
+Let's implement a dummy address handler which works with `String` addresses without any restrictions.
+
+```rust
+pub struct DummyAddressHandler;
+
+impl AddressHandler for CoolAddressHandler {
+    fn addr_canonicalize(input: &str) -> Result<Vec<u8>, VmError> {
+        // We just convert the address into binary
+        Ok(input.as_bytes())
+    }
+
+    fn addr_humanize(addr: &[u8]) -> Result<String, VmError> {
+        String::from_utf8(addr.into()).map_err(|_| VmError::InvalidAddress)
+    }
+
+    fn addr_generate<'a, I: IntoIterator<Item = &'a [u8]>>(iter: I) -> Result<String, VmError> {       
+        // Just hash the inputs
+        let mut hash = Sha256::new();
+        for data in iter {
+            hash = hash.chain_update(data);
+        }
+        Self::addr_humanize(hash.finalize().as_ref())
+    }
+}
+```
+
+Then follow the above steps to use it in your tests and that's all.

--- a/docs/orchestrate/src/concepts/address-handlers.md
+++ b/docs/orchestrate/src/concepts/address-handlers.md
@@ -1,11 +1,11 @@
 # Address Handlers
 
-Throughout this documentation, you see that we always use `JunoApi`. But there are 
-few other API's as well like `WasmApi`, `SubstrateApi`, etc. The only difference between
-this API's is how they handle the address generation, validation and canonicalization.
+Throughout this documentation, you see that we always use `JunoApi`. But there are a 
+few other APIs as well like `WasmApi`, `SubstrateApi`, etc. The only difference between
+these APIs is how they handle address generation, validation, and canonicalization.
 
-For example, Cosmos API's like `JunoApi` or `WasmApi` uses `Bech32` encoding and `JunoApi` uses
-`juno` as prefix and `WasmApi` uses `wasm` as prefix.
+For example, Cosmos APIs like `JunoApi` or `WasmApi` use `Bech32` encoding and `JunoApi` uses
+`juno` as the prefix and `WasmApi` uses `wasm` as the prefix.
 
 ## Creating your own Cosmos address handler
 
@@ -51,7 +51,7 @@ And you will use the `CoolApi` for API calls:
 
 You can also implement an address handler from scratch by implementing `AddressHandler` trait.
 
-Let's implement a dummy address handler which works with `String` addresses without any restrictions.
+Let's implement a dummy address handler that works with `String` addresses without any restrictions.
 
 ```rust
 struct DummyAddressHandler;

--- a/docs/orchestrate/src/concepts/address-handlers.md
+++ b/docs/orchestrate/src/concepts/address-handlers.md
@@ -54,19 +54,19 @@ You can also implement an address handler from scratch by implementing `AddressH
 Let's implement a dummy address handler which works with `String` addresses without any restrictions.
 
 ```rust
-pub struct DummyAddressHandler;
+struct DummyAddressHandler;
 
-impl AddressHandler for CoolAddressHandler {
+impl AddressHandler for DummyAddressHandler {
     fn addr_canonicalize(input: &str) -> Result<Vec<u8>, VmError> {
         // We just convert the address into binary
-        Ok(input.as_bytes())
+        Ok(input.as_bytes().into())
     }
 
     fn addr_humanize(addr: &[u8]) -> Result<String, VmError> {
         String::from_utf8(addr.into()).map_err(|_| VmError::InvalidAddress)
     }
 
-    fn addr_generate<'a, I: IntoIterator<Item = &'a [u8]>>(iter: I) -> Result<String, VmError> {       
+    fn addr_generate<'a, I: IntoIterator<Item = &'a [u8]>>(iter: I) -> Result<String, VmError> {
         // Just hash the inputs
         let mut hash = Sha256::new();
         for data in iter {

--- a/docs/orchestrate/src/concepts/concepts.md
+++ b/docs/orchestrate/src/concepts/concepts.md
@@ -1,0 +1,9 @@
+# Concepts
+
+There are few concepts that is good for a user to know, these are:
+
+* [`Direct` and `Dispatch` execution types](./direct-dispatch.md): Explains the behaviors of `Direct`
+and `Dispatch` execution types and their use cases.
+* [Address handlers](./address-handlers.md): Explains why we have different `Api`'s and how you can
+implement your own address handler based on your needs.
+* [Custom message/query handler](./custom-handler.md): Explains how a user can enable handling of `CosmosMsg::Custom` and `QueryRequest::Custom`.

--- a/docs/orchestrate/src/concepts/concepts.md
+++ b/docs/orchestrate/src/concepts/concepts.md
@@ -1,9 +1,9 @@
 # Concepts
 
-There are few concepts that is good for a user to know, these are:
+There are a few concepts that are good for a user to know, these are:
 
 * [`Direct` and `Dispatch` execution types](./direct-dispatch.md): Explains the behaviors of `Direct`
 and `Dispatch` execution types and their use cases.
-* [Address handlers](./address-handlers.md): Explains why we have different `Api`'s and how you can
-implement your own address handler based on your needs.
+* [Address handlers](./address-handlers.md): Explains why we have different APIs and how you can
+implement your address handler based on your needs.
 * [Custom message/query handler](./custom-handler.md): Explains how a user can enable handling of `CosmosMsg::Custom` and `QueryRequest::Custom`.

--- a/docs/orchestrate/src/concepts/custom-handler.md
+++ b/docs/orchestrate/src/concepts/custom-handler.md
@@ -1,0 +1,64 @@
+# Custom Message Handler
+
+`CustomMsg` calls result in `NotSupported` error in the default implementation. But our 
+framework is flexible enough to let you define your own custom message logic.
+
+
+## Implementing a custom message handler
+
+If your chain supports `CosmosMsg::Custom`, you can simply implement the `CustomHandler`
+trait in our framework and handle custom messages and queries. Note that your `CustomHandler`
+type needs to implement `Clone` because it will get reverted if the transaction fails.
+
+```rust
+/// Type that implements the CustomHandler
+#[derive(Default, Clone)]
+pub struct MyCustomHandler;
+
+/// Custom message type
+pub struct MyCustomMessage;
+
+/// Custom query type 
+pub struct MyCustomQuery;
+
+impl CustomHandler for MyCustomHandler {
+    type QueryCustom = MyCustomQuery;
+    type MessageCustom = MyCustomMessage;
+
+    fn handle_message<AH: AddressHandler>(
+        vm: &mut Context<Self, AH>,
+        message: MyCustomMessage,
+        event_handler: &mut dyn FnMut(Event),
+    ) -> Result<Option<Binary>, VmError> {
+        self.state.db.custom_handler.do_something_with_message(message);
+    }
+
+    fn handle_query<AH: AddressHandler>(
+        vm: &mut Context<Self, AH>,
+        query: MyCustomQuery,
+    ) -> Result<SystemResult<CosmwasmQueryResult>, VmError> {
+        self.state.db.custom_handler.do_something_with_query(query);
+    }
+}
+```
+
+Then you again need to create an `Api` type which uses `MyCustomHandler`.
+
+```rust
+pub type CustomJunoApi<'a, E = Dispatch> = Api<
+    'a,
+    E,
+    JunoAddressHandler,
+    State<MyCustomHandler, JunoAddressHandler>,
+    Context<'a, MyCustomHandler, JunoAddressHandler>,
+>;
+```
+
+One more thing is, you need to provide `MyCustomHandler` to the `StateBuilder`.
+
+```rust
+let state = StateBuilder::<JunoAddressHandler>::new()
+    .add_code(&code)
+    .set_custom_handler(MyCustomHandler)
+    .build();
+```

--- a/docs/orchestrate/src/concepts/direct-dispatch.md
+++ b/docs/orchestrate/src/concepts/direct-dispatch.md
@@ -1,0 +1,42 @@
+# `Direct` and `Dispatch` API's 
+
+Sometimes, it might be not required to do a complete simulation of an entrypoint.
+For example, you might wanna execute `instantiate` entrypoint but you might just wanna
+get the `instantiate` functions result and don't proceed to sub-message execution.
+Therefore, there are two execution types that handles exactly this: `Direct` and `Dispatch`.
+
+
+## Dispatch
+
+When you want to simulate a complete execution like how a transaction is handled in a real environment, `Dispatch` is used.
+`Dispatch` executes the entrypoint you call and also handles the sub-messages. It commits the transaction
+changes when the execution succeeds and aborts it when the execution fails.
+
+Note that the same error handling mechanism is valid here as well. In the case of an error in the top-level contract,
+the transaction will be reverted, otherwise, the behavior will be up to the user (catching errors with `Reply`).
+
+`Dispatch` is the default execution type of `Api`'s. So you don't need to specify `Dispatch`
+like `JunoApi::<Dispatch>::..`. But note that, because of the limitations of rust's type
+inference, you can't do `JunoApi::instantiate`, but need to use it like `<JunoApi>::instantiate` for
+Rust to infer the generic types for you.
+
+
+## Direct
+
+Some entrypoints like `query` are not meant to be `Dispatch` and also sometimes you might to just 
+run an entrypoint and get the `Response` without running and sub-messages or creating a transaction. 
+`Direct` is used in this case. Running a dispatchable entrypoint(eg. `instantiate`) with `Direct` is like a unit-test.
+
+But the notable thing is some entrypoints like `instantiate` might modify the storage. And since they are not
+handled like `Dispatch`, the changes won't get reverted if the execution fails. It is not a big deal since
+you will probably want to abort the test in case of failure anyways. But if for some reason you want to call
+a dispatchable entrypoint and make sure that the storage modifications are not persisted, you can just create
+a seperate state for each run.
+
+You can set the execution type to `Direct` by specifying it during the call:
+
+```rust
+JunoApi::<Direct>::instantiate();
+// or
+<JunoApi<Direct>>::instantiate();
+```

--- a/docs/orchestrate/src/concepts/direct-dispatch.md
+++ b/docs/orchestrate/src/concepts/direct-dispatch.md
@@ -1,21 +1,21 @@
-# `Direct` and `Dispatch` API's 
+# `Direct` and `Dispatch` APIs 
 
-Sometimes, it might be not required to do a complete simulation of an entrypoint.
-For example, you might wanna execute `instantiate` entrypoint but you might just wanna
+Sometimes, it might be not required to do a complete simulation of an entry point.
+For example, you might wanna execute `instantiate` entry point but you might just wanna
 get the `instantiate` functions result and don't proceed to sub-message execution.
-Therefore, there are two execution types that handles exactly this: `Direct` and `Dispatch`.
+Therefore, there are two execution types that handle exactly this: `Direct` and `Dispatch`.
 
 
 ## Dispatch
 
 When you want to simulate a complete execution like how a transaction is handled in a real environment, `Dispatch` is used.
-`Dispatch` executes the entrypoint you call and also handles the sub-messages. It commits the transaction
+`Dispatch` executes the entry point you call and also handles the sub-messages. It commits the transaction
 changes when the execution succeeds and aborts it when the execution fails.
 
-Note that the same error handling mechanism is valid here as well. In the case of an error in the top-level contract,
+Note that the same error-handling mechanism is valid here as well. In the case of an error in the top-level contract,
 the transaction will be reverted, otherwise, the behavior will be up to the user (catching errors with `Reply`).
 
-`Dispatch` is the default execution type of `Api`'s. So you don't need to specify `Dispatch`
+`Dispatch` is the default execution type of `API`s. So you don't need to specify `Dispatch`
 like `JunoApi::<Dispatch>::..`. But note that, because of the limitations of rust's type
 inference, you can't do `JunoApi::instantiate`, but need to use it like `<JunoApi>::instantiate` for
 Rust to infer the generic types for you.
@@ -23,15 +23,15 @@ Rust to infer the generic types for you.
 
 ## Direct
 
-Some entrypoints like `query` are not meant to be `Dispatch` and also sometimes you might to just 
-run an entrypoint and get the `Response` without running and sub-messages or creating a transaction. 
-`Direct` is used in this case. Running a dispatchable entrypoint(eg. `instantiate`) with `Direct` is like a unit-test.
+Some entry points like `query` are not meant to be `Dispatch` and also sometimes you might just 
+run an entry point and get the `Response` without running sub-messages or creating a transaction. 
+`Direct` is used in this case. Running a dispatchable entry point(eg. `instantiate`) with `Direct` is like a unit test.
 
-But the notable thing is some entrypoints like `instantiate` might modify the storage. And since they are not
+But the notable thing is some entry points like `instantiate` might modify the storage. And since they are not
 handled like `Dispatch`, the changes won't get reverted if the execution fails. It is not a big deal since
 you will probably want to abort the test in case of failure anyways. But if for some reason you want to call
-a dispatchable entrypoint and make sure that the storage modifications are not persisted, you can just create
-a seperate state for each run.
+a dispatchable entry point and make sure that the storage modifications are not persisted, you can just create
+a separate state for each run.
 
 You can set the execution type to `Direct` by specifying it during the call:
 

--- a/docs/orchestrate/src/concepts/direct-dispatch.md
+++ b/docs/orchestrate/src/concepts/direct-dispatch.md
@@ -1,8 +1,8 @@
 # `Direct` and `Dispatch` APIs 
 
 Sometimes, it might be not required to do a complete simulation of an entry point.
-For example, you might wanna execute `instantiate` entry point but you might just wanna
-get the `instantiate` functions result and don't proceed to sub-message execution.
+For example, you might wanna execute `instantiate` entry point but you might just want to
+get the `instantiate` functions result and not proceed to sub-message execution.
 Therefore, there are two execution types that handle exactly this: `Direct` and `Dispatch`.
 
 

--- a/docs/orchestrate/src/tutorial-dex.md
+++ b/docs/orchestrate/src/tutorial-dex.md
@@ -1,0 +1,1 @@
+# Tutorial

--- a/docs/orchestrate/src/tutorial-dex.md
+++ b/docs/orchestrate/src/tutorial-dex.md
@@ -1,3 +1,421 @@
 # Tutorial: Testing a DEX 
 
+Let's see a real world example by testing `wasmswap`. We are going to swap the native token `cosm`
+with the Cw20 token `pica`.
 
+## Setting up
+
+We are using a slightly modified version of `wasmswap`. The only difference is our VM doesn't alter
+the `data` field because it is supposed to be up-to user to use any data in any format. So we chose
+to follow the spec there. Let's clone the template for our tutorial:
+
+```sh
+git clone https://github.com/ComposableFi/cw-toolkit
+cd cw-toolkit
+git checkout tags/wasmswap-template
+cd orchestrate-tutorial
+```
+
+Add the latest `cosmwasm-orchestrate` as a `dev-dependency`:
+
+```toml
+# In Cargo.toml
+
+[dev-dependencies]
+cosmwasm-orchestrate = { git = "https://github.com/ComposableFi/cosmwasm-vm" }
+```
+
+And let's create a file for the integration tests:
+
+```bash
+mkdir tests
+touch tests/integration.rs
+```
+
+## Setting up the state for the test
+
+### Code
+
+```rust
+// In `integration.rs`
+
+use cosmwasm_orchestrate::{
+    block,
+    cosmwasm_std::{Coin, MessageInfo},
+    env, info,
+    vm::*,
+    Direct, JunoApi, StateBuilder, WasmLoader,
+};
+use cosmwasm_std::{Addr, Decimal, Uint128};
+use cw20::{BalanceResponse, Cw20Coin, Cw20ExecuteMsg, Cw20QueryMsg, Denom};
+use cw20_base::msg::InstantiateMsg as Cw20InstantiateMsg;
+use wasmswap::msg::{ExecuteMsg, InstantiateMsg, TokenSelect};
+
+#[test]
+fn swap_works() {
+    // Compile and load the wasmswap contract
+    let wasmswap_code = WasmLoader::new(env!("CARGO_PKG_NAME")).load().unwrap();
+    let cw20_code = include_bytes!("../scripts/cw20_base.wasm");
+    // Create a VM state by providing the codes that will be executed.
+    let mut state = StateBuilder::new()
+        .add_code(&wasmswap_code)
+        .add_code(cw20_code)
+        .build();
+}
+```
+
+If you were to build your test right now, it will fail but we'll shortly make it work, no worries.
+
+### Inspection
+
+```rust
+let cw20_code = include_bytes!("../scripts/cw20_base.wasm");
+```
+For loading `cw20_base` contract, we just used `include_bytes` because we have the binary locally.
+But if you need to get this binary from a (reliable) remote source, you could also use:
+* `CosmosFetcher`: To fetch the code from a Cosmos chain.
+* `FileFetcher`: To fetch the code from a server. (Like using `wget`)
+
+---
+
+```rust
+let wasmswap_code = WasmLoader::new(env!("CARGO_PKG_NAME")).load().unwrap();
+```
+For the wasmswap contract, we used a special type of loader which is `WasmLoader`. The thing is
+our VM works with wasm binaries just like any other chain. So we need to make sure that we are
+feeding the VM with the latest compiled wasm binary everytime we run the tests. We could manually
+compile the binary and just do `include_bytes` but believe me, you will forget to do it very often
+and get confused. 
+
+`WasmLoader` gets the package name and compiles and loads the contract for you. Note that the default
+configuration assumes the rust package name is the same as the contract name. So `wasmswap` as package
+name means that the contract's name is also `wasmswap` and the full name will be `wasmswap.wasm`.
+The second assumption of the default loader is the target directory is `target/wasm32-unknown-unknown/release`.
+The good thing is you can configure any of those, even the command that will be used to build your 
+contract.
+
+---
+
+```rust
+let mut state = StateBuilder::new()
+    .add_code(&wasmswap_code) // code_id = 1
+    .add_code(cw20_code)      // code_id = 2
+    .build();
+```
+Finally, we need to create a `State` for the VM which will contain the wasm binaries. Note that 
+code id's that we are gonna use later on will be in the same order as how it is given to the `StateBuilder`.
+So in this case, `code_id` for `wasmswap_code` will be `1` and `2` for `cw20_code`.
+
+## Instantiating the token
+
+Let's instantiate the `cw20` contract for `PICA`.
+
+### Code
+```rust
+    let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
+
+    // Instantiate the cw20 contract
+    let (cw20_address, _) = <JunoApi>::instantiate(
+        &mut state,
+        2,  // Code ID of cw20_base is 2
+        None,
+        block(),
+        None,
+        info(&sender),
+        100_000_000_000,
+        Cw20InstantiateMsg {
+            name: "Picasso".into(),
+            symbol: "PICA".into(),
+            decimals: 10,
+            initial_balances: vec![Cw20Coin {
+                address: sender.clone().into(),
+                amount: Uint128::new(100_000_000_000_000),
+            }],
+            mint: None,
+            marketing: None,
+        },
+    )
+    .unwrap();
+```
+
+To run, use:
+```rust
+cargo test --test integration
+```
+
+### Analyze
+
+```rust
+let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
+```
+
+We need to create a valid address which we are gonna use to call the contracts. Which is basically
+`sender` field in `MessageInfo`. For that, we are using `Account` type with `JunoAddressHandler`.
+This will create a `bech32` encoded address with `juno` prefix.
+
+---
+
+```rust
+let (cw20_address, _) = <JunoApi>::instantiate(
+    &mut state,
+    2,  // Code ID of cw20_base is 2
+    None,
+    block(),
+    None,
+    info(&sender),
+    100_000_000_000, // We don't care about the gas
+    Cw20InstantiateMsg {
+        name: "Picasso".into(),
+        symbol: "PICA".into(),
+        decimals: 10,
+        initial_balances: vec![Cw20Coin {
+            address: sender.clone().into(),
+            amount: Uint128::new(100_000_000_000_000),
+        }],
+        mint: None,
+        marketing: None,
+    },
+)
+.unwrap();
+```
+
+And then we are instantiating the `cw20` contract. First notable thing is we are using `JunoApi` because
+we have used the `JunoAddressHandler`. `JunoApi` will use `JunoAddressHandler` as the address handler.
+
+Note that we are giving instantiate message as is without doing any json encoding. This is because
+`instantiate` function gets any json-serializable type and serializes it under the hood. But if you
+have no access to message type and you don't want to define them yourself, you can use `instantiate_raw`
+function and provide the json-encoded message.
+
+Finally, note that we do `info(&sender)` which creates a `MessageInfo` and sets the `sender` field to
+the given account's address.
+
+## Instantiating the swap
+
+Next thing is to instantiate the swap with the token we just created.
+
+```rust
+    let (contract_addr, _) = <JunoApi>::instantiate(
+        &mut state,
+        1, // Code ID for wasmswap is 1
+        None,
+        block(),
+        None,
+        info(&sender),
+        100_000_000_000,
+        InstantiateMsg {
+            token1_denom: Denom::Native("cosm".into()),
+            token2_denom: Denom::Cw20(Addr::unchecked(cw20_address.clone())),
+            lp_token_code_id: 2,
+            owner: None,
+            protocol_fee_recipient: sender.clone().into(),
+            protocol_fee_percent: Decimal::zero(),
+            lp_fee_percent: Decimal::zero(),
+        },
+    )
+    .unwrap();
+```
+
+Just as we instantiated the `cw20` token, we instantiated the swap. Note that `cw20_address` that
+we got from the previous token instantiation is given to the swap contract as the `cw20` token.
+
+And also, `lp_token_code_id` is set to `2` which is the code id for `cw20_base`.
+
+## Increasing allowance
+
+Before executing the swap, we need to make sure that the swap contract has the allowance to transfer tokens
+from the account that does the swap. So let's create a second account and increase the allowance for the
+swap contract.
+
+```rust
+    // Create the second account which will do the swap
+    let swapper = Account::generate_from_seed::<JunoAddressHandler>("swapper").unwrap();
+
+    let _ = <JunoApi>::execute(
+        &mut state,
+        env(&cw20_address),
+        info(&sender),
+        100_000_000_000,
+        Cw20ExecuteMsg::IncreaseAllowance {
+            spender: contract_addr.clone().into(),
+            amount: Uint128::new(100_000_000_000),
+            expires: Some(cw0::Expiration::Never {}),
+        },
+    )
+    .unwrap();
+```
+
+Note that we have given `cw20_address` to the `env` function. This will create an `Env` and set 
+`contract.address` field to the given address and this contract will be executed.
+
+## Adding liquidity to the swap
+
+We also need to have enough liquidity to be able to do the swap. So let's add some juice.
+
+```rust
+    let _ = <JunoApi>::execute(
+        &mut state,
+        env(&contract_addr),
+        MessageInfo {
+            sender: sender.clone().into(),
+            funds: vec![Coin::new(400_000_000, "cosm")],
+        },
+        100_000_000_000,
+        ExecuteMsg::AddLiquidity {
+            token1_amount: 400_000_000u128.into(),
+            min_liquidity: 50_000u128.into(),
+            max_token2: 300_000_000u128.into(),
+            expiration: None,
+        },
+    )
+    .unwrap();
+```
+
+And when we execute it:
+```sh
+thread 'works' panicked at 'called `Result::unwrap()` on an `Err` value: BankError(InsufficientBalance)', tests/orchestrate.rs:109:6
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+```
+
+WHAT THE HELL?
+
+No worries, it is intended to show you how to easily understand what went wrong. Our VM logs too many
+great things about the execution flow which includes the error messages. So let's enable logs to see
+all that yummy logs.
+
+```toml
+# In Cargo.toml
+env_logger = "0.10"
+```
+
+```rust
+// In integration.rs
+
+fn initialize() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        env_logger::init();
+    });
+}
+
+#[test]
+fn swap_works() {
+    initialize();
+}
+
+```
+
+And then let's execute the test once more with enabling the logs.
+
+```rust
+RUST_LOG=debug cargo test --test integration
+```
+
+Before going into the reason of failure, take your time to read the logs and see how much useful information
+there is. You are able to see the host functions that are running, responses from the executions and
+submessages that are dispatched.
+
+Now let's see what went wrong:
+```
+[2022-12-11T20:10:53Z DEBUG cosmwasm_orchestrate::vm] Transfer: 
+    Account(Addr("juno1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwm56ug")) 
+    -> Account(Addr("juno1ptl22cw3jth6ue4ruhgef2s5gfz23tt57vlrmydqu7vxk5xhn4gse7s6fe"))
+    [Coin { denom: "cosm", amount: Uint128(400000000) }]
+
+[2022-12-11T20:10:53Z DEBUG cosmwasm_orchestrate::vm] < Transaction abort: 0
+```
+
+The VM is trying to transfer `400_000_000cosm` and then it aborts the transaction with `BankError(InsufficientBalance)`.
+
+The problem is obvious. See that we needed to transfer some funds to the contract to be able to add the
+liquidity by properly setting `funds` field in the `MessageInfo`. But the `sender` account does not have
+any `cosm` balance at all. So, the VM tried to transfer the given funds to the contract before execution
+and failed.
+
+Let's add some balance to the `sender` account in the `StateBuilder`.
+
+```rust
+    // Change the `StateBuilder` to:
+    let mut state = StateBuilder::new()
+        .add_code(&wasmswap_code)
+        .add_balance(sender.clone(), Coin::new(100_000_000_000_000, "cosm"))
+        .add_code(cw20_code)
+        .build();
+
+```
+
+Now that we have enough balance, let's re-run again and see the lovely green `ok` message.
+
+## `cosmwasm_std` vs. `cosmwasm_orchestrate::cosmwasm_std`
+
+You might have already noticed it but we are using `Coin` and `MessageInfo` from `cosmwasm_orchestrate::cosmwasm_std`
+instead of using them directly from `cosmwasm_std`. This is a temporary thing which we hope to resolve
+soon. The problem is our VM is `no_std` but `cosmwasm_std` is originally only `std`. We created a PR
+for this and until it gets merged, `cosmwasm-orchestrate` will be using our fork, hence `Cargo` thinks
+that `cosmwasm_std::Coin` is not the same thing as `cosmwasm_orchestrate::cosmwasm_std::Coin`. Until the
+merge, for any type/function that is given to `cosmwasm-orchestrate`, use `cosmwasm_orchestrate::cosmwasm_std`.
+You will get a type mismatch error if you do it wrong, so beware of that.
+
+## Executing the swap
+```rust
+    // Change the `StateBuilder` to:
+    let mut state = StateBuilder::new()
+        .add_code(&wasmswap_code)
+        .add_balance(sender.clone(), Coin::new(100_000_000_000_000, "cosm"))
+        .add_balance(swapper.clone(), Coin::new(120_000_000, "cosm"))
+        .add_code(cw20_code)
+        .build();
+
+    let _ = <JunoApi>::execute(
+        &mut state,
+        env(&contract_addr),
+        MessageInfo {
+            sender: swapper.clone().into(),
+            funds: vec![Coin::new(120_000_000, "cosm")],
+        },
+        100_000_000_000,
+        ExecuteMsg::Swap {
+            input_token: TokenSelect::Token1,
+            input_amount: Uint128::new(120_000_000),
+            min_output: Uint128::zero(),
+            expiration: None,
+        },
+    )
+    .unwrap();
+```
+
+Note that we add balance to `swapper` account as well to be able to send funds to the swap contract.
+And finally, we are able to swap `120_000_000cosm`. The final thing to do is verify the swap worked.
+
+## Verifying the swap
+
+We will check `swapper`'s `pica` balance to verify the swap. To do that, we need to query the `cw20` token.
+
+```rust
+    let query_res: BalanceResponse = <JunoApi<Direct>>::query(
+        &mut state,
+        env(&cw20_address),
+        Cw20QueryMsg::Balance {
+            address: swapper.clone().into(),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        query_res.balance,
+        Uint128::new((120_000_000 * 300_000_000) / (400_000_000 + 120_000_000))
+    );
+```
+
+Note that we used `<JunoApi<Direct>>` this time instead of `<JunoApi>`. This is because the execution
+type for `query` can only be `Direct`. See previous sections to learn more about this.
+
+And here we verified the whole execution.
+
+One final note is if you were to verify the native balances also, you could directly use the bank module
+to see the balances:
+
+```rust
+state.db.bank.balance(&swapper, "cosm");
+```

--- a/docs/orchestrate/src/tutorial-dex.md
+++ b/docs/orchestrate/src/tutorial-dex.md
@@ -1,12 +1,12 @@
 # Tutorial: Testing a DEX 
 
-Let's see a real world example by testing `wasmswap`. We are going to swap the native token `cosm`
+Let's see a real-world example by testing `wasmswap`. We are going to swap the native token `cosm`
 with the Cw20 token `pica`.
 
 ## Setting up
 
 We are using a slightly modified version of `wasmswap`. The only difference is our VM doesn't alter
-the `data` field because it is supposed to be up-to user to use any data in any format. So we chose
+the `data` field because it is supposed to be up to user to use any data in any format. So we chose
 to follow the spec there. Let's clone the template for our tutorial:
 
 ```sh
@@ -83,12 +83,12 @@ let wasmswap_code = WasmLoader::new(env!("CARGO_PKG_NAME")).load().unwrap();
 ```
 For the wasmswap contract, we used a special type of loader which is `WasmLoader`. The thing is
 our VM works with wasm binaries just like any other chain. So we need to make sure that we are
-feeding the VM with the latest compiled wasm binary everytime we run the tests. We could manually
+feeding the VM with the latest compiled wasm binary every time we run the tests. We could manually
 compile the binary and just do `include_bytes` but believe me, you will forget to do it very often
 and get confused. 
 
 `WasmLoader` gets the package name and compiles and loads the contract for you. Note that the default
-configuration assumes the rust package name is the same as the contract name. So `wasmswap` as package
+configuration assumes the rust package name is the same as the contract name. So `wasmswap` as the package
 name means that the contract's name is also `wasmswap` and the full name will be `wasmswap.wasm`.
 The second assumption of the default loader is the target directory is `target/wasm32-unknown-unknown/release`.
 The good thing is you can configure any of those, even the command that will be used to build your 
@@ -149,7 +149,7 @@ cargo test --test integration
 let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
 ```
 
-We need to create a valid address which we are gonna use to call the contracts. Which is basically
+We need to create a valid address which we are gonna use to call the contracts. Which is the
 `sender` field in `MessageInfo`. For that, we are using `Account` type with `JunoAddressHandler`.
 This will create a `bech32` encoded address with `juno` prefix.
 
@@ -179,13 +179,13 @@ let (cw20_address, _) = <JunoApi>::instantiate(
 .unwrap();
 ```
 
-And then we are instantiating the `cw20` contract. First notable thing is we are using `JunoApi` because
+And then we are instantiating the `cw20` contract. The first notable thing is we are using `JunoApi` because
 we have used the `JunoAddressHandler`. `JunoApi` will use `JunoAddressHandler` as the address handler.
 
-Note that we are giving instantiate message as is without doing any json encoding. This is because
-`instantiate` function gets any json-serializable type and serializes it under the hood. But if you
+Note that we are giving the instantiate message as is without doing any JSON encoding. This is because
+`instantiate` function gets any JSON-serializable type and serializes it under the hood. But if you
 have no access to message type and you don't want to define them yourself, you can use `instantiate_raw`
-function and provide the json-encoded message.
+function and provide the JSON-encoded message.
 
 Finally, note that we do `info(&sender)` which creates a `MessageInfo` and sets the `sender` field to
 the given account's address.
@@ -312,9 +312,9 @@ And then let's execute the test once more with enabling the logs.
 RUST_LOG=debug cargo test --test integration
 ```
 
-Before going into the reason of failure, take your time to read the logs and see how much useful information
-there is. You are able to see the host functions that are running, responses from the executions and
-submessages that are dispatched.
+Before going into the reason for failure, take your time to read the logs and see how much useful information
+there is. You can see the host functions that are running, responses from the executions, and
+sub-messages that are dispatched.
 
 Now let's see what went wrong:
 ```
@@ -350,7 +350,7 @@ Now that we have enough balance, let's re-run again and see the lovely green `ok
 ## `cosmwasm_std` vs. `cosmwasm_orchestrate::cosmwasm_std`
 
 You might have already noticed it but we are using `Coin` and `MessageInfo` from `cosmwasm_orchestrate::cosmwasm_std`
-instead of using them directly from `cosmwasm_std`. This is a temporary thing which we hope to resolve
+instead of using them directly from `cosmwasm_std`. This is a temporary thing that we hope to resolve
 soon. The problem is our VM is `no_std` but `cosmwasm_std` is originally only `std`. We created a PR
 for this and until it gets merged, `cosmwasm-orchestrate` will be using our fork, hence `Cargo` thinks
 that `cosmwasm_std::Coin` is not the same thing as `cosmwasm_orchestrate::cosmwasm_std::Coin`. Until the
@@ -386,7 +386,7 @@ You will get a type mismatch error if you do it wrong, so beware of that.
 ```
 
 Note that we add balance to `swapper` account as well to be able to send funds to the swap contract.
-And finally, we are able to swap `120_000_000cosm`. The final thing to do is verify the swap worked.
+And finally, we can swap `120_000_000cosm`. The final thing to do is verify the swap worked.
 
 ## Verifying the swap
 

--- a/docs/orchestrate/src/tutorial-dex.md
+++ b/docs/orchestrate/src/tutorial-dex.md
@@ -1,1 +1,3 @@
-# Tutorial
+# Tutorial: Testing a DEX 
+
+

--- a/orchestrate/Cargo.toml
+++ b/orchestrate/Cargo.toml
@@ -12,9 +12,8 @@ cosmwasm-std = { git = "https://github.com/ComposableFi/cosmwasm", rev = "21351c
   "stargate",
   "ibc3",
   "staking"
-
 ] }
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
+cosmwasm-crypto = { git = "https://github.com/ComposableFi/cosmwasm", rev = "21351cc1ced863b9af7c8a69f923036bc919b3b1" }
 serde_json = "1.0"
 serde = { version = "1.0", default-features = false, features = [
   "alloc",
@@ -23,13 +22,7 @@ serde = { version = "1.0", default-features = false, features = [
 wasmi = { git = "https://github.com/ComposableFi/wasmi", rev = "cd8c0c775a1d197a35ff3d5c7d6cded3d476411b", default-features = false }
 wasm-instrument = { version = "0.2", default-features = false }
 log = { version = "0.4", default-features = false }
-env_logger = { version = "0.10" }
-cosmwasm-crypto = { git = "https://github.com/ComposableFi/cosmwasm", rev = "21351cc1ced863b9af7c8a69f923036bc919b3b1" }
-sha1 = { version = "0.10", default-features = false }
 sha2 = { version = "0.10", default-features = false }
-cw20-ics20-contract = { package = "cw20-ics20", git = "https://github.com/CosmWasm/cw-plus", rev = "53dc88fdb81888cbd3dae8742e7318b35d3d0c0f", default-features = false, features = [
-  "library",
-] }
 reqwest = { version = "0.11", features = ["blocking"] }
 base64 = "0.13.1"
 async-trait = { version = "0.1.58" }
@@ -40,3 +33,5 @@ bs58 = { version = "0.4.0", default-features = false, features = [ "alloc" ] }
 cw20 = "0.16"
 cw20-base = { version = "0.16", features = ["library"] }
 tokio = { version = "1.22", features = [ "rt", "macros" ] }
+env_logger = { version = "0.10" }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/orchestrate/Cargo.toml
+++ b/orchestrate/Cargo.toml
@@ -33,6 +33,8 @@ cw20-ics20-contract = { package = "cw20-ics20", git = "https://github.com/CosmWa
 reqwest = { version = "0.11", features = ["blocking"] }
 base64 = "0.13.1"
 async-trait = { version = "0.1.58" }
+bech32 = { version = "0.9.1", default-features = false }
+bs58 = { version = "0.4.0", default-features = false, features = [ "alloc" ] }
 
 [dev-dependencies]
 cw20 = "0.16"

--- a/orchestrate/examples/custom_address_handler.rs
+++ b/orchestrate/examples/custom_address_handler.rs
@@ -1,0 +1,66 @@
+use cosmwasm_orchestrate::{
+    fetcher::FileFetcher,
+    vm::{Account, AddressHandler, Context, CosmosAddressHandler, State, VmError},
+    *,
+};
+use sha2::{Digest, Sha256};
+
+const REFLECT_URL: &'static str =
+    "https://github.com/CosmWasm/cosmwasm/releases/download/v1.1.8/reflect.wasm";
+
+pub struct CustomCosmosAddressHandler;
+
+impl CosmosAddressHandler for CustomCosmosAddressHandler {
+    const PREFIX: &'static str = "cosmos";
+}
+
+pub type CosmosApi<'a, E = Dispatch> = Api<
+    'a,
+    E,
+    CustomCosmosAddressHandler,
+    State<(), CustomCosmosAddressHandler>,
+    Context<'a, (), CustomCosmosAddressHandler>,
+>;
+
+#[allow(unused)]
+struct DummyAddressHandler;
+
+impl AddressHandler for DummyAddressHandler {
+    fn addr_canonicalize(input: &str) -> Result<Vec<u8>, VmError> {
+        // We just convert the address into binary
+        Ok(input.as_bytes().into())
+    }
+
+    fn addr_humanize(addr: &[u8]) -> Result<String, VmError> {
+        String::from_utf8(addr.into()).map_err(|_| VmError::InvalidAddress)
+    }
+
+    fn addr_generate<'a, I: IntoIterator<Item = &'a [u8]>>(iter: I) -> Result<String, VmError> {
+        // Just hash the inputs
+        let mut hash = Sha256::new();
+        for data in iter {
+            hash = hash.chain_update(data);
+        }
+        Self::addr_humanize(hash.finalize().as_ref())
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let code = FileFetcher::from_url(REFLECT_URL).await.unwrap();
+    let sender = Account::generate_from_seed::<CustomCosmosAddressHandler>("sender").unwrap();
+    let mut state = StateBuilder::<CustomCosmosAddressHandler>::new()
+        .add_code(&code)
+        .build();
+    let _ = <CosmosApi>::instantiate_raw(
+        &mut state,
+        1,
+        None,
+        block(),
+        None,
+        info(&sender),
+        100_000_000,
+        r#"{}"#.as_bytes(),
+    )
+    .unwrap();
+}

--- a/orchestrate/examples/custom_handler.rs
+++ b/orchestrate/examples/custom_handler.rs
@@ -1,0 +1,86 @@
+use cosmwasm_orchestrate::{
+    fetcher::FileFetcher,
+    vm::{Account, AddressHandler, Context, CustomHandler, JunoAddressHandler, State, VmError},
+    *,
+};
+use cosmwasm_std::{Binary, Event, SystemResult};
+use cosmwasm_vm::executor::CosmwasmQueryResult;
+use serde::Deserialize;
+
+const REFLECT_URL: &'static str =
+    "https://github.com/CosmWasm/cosmwasm/releases/download/v1.1.8/reflect.wasm";
+
+#[derive(Default, Clone)]
+pub struct MyCustomHandler {}
+
+impl MyCustomHandler {
+    fn do_something_with_message(&self, message: MyCustomMessage) {
+        println!("MESSAGE: {:?}", message);
+    }
+
+    fn do_something_with_query(&self, query: MyCustomQuery) {
+        println!("QUERY: {:?}", query);
+    }
+}
+
+/// Custom message type
+#[derive(Debug, Deserialize)]
+pub struct MyCustomMessage;
+
+/// Custom query type
+#[derive(Debug, Deserialize)]
+pub struct MyCustomQuery;
+
+impl CustomHandler for MyCustomHandler {
+    type QueryCustom = MyCustomQuery;
+    type MessageCustom = MyCustomMessage;
+
+    fn handle_message<AH: AddressHandler>(
+        vm: &mut Context<Self, AH>,
+        message: MyCustomMessage,
+        _event_handler: &mut dyn FnMut(Event),
+    ) -> Result<Option<Binary>, VmError> {
+        vm.state
+            .db
+            .custom_handler
+            .do_something_with_message(message);
+        Ok(None)
+    }
+
+    fn handle_query<AH: AddressHandler>(
+        vm: &mut Context<Self, AH>,
+        query: MyCustomQuery,
+    ) -> Result<SystemResult<CosmwasmQueryResult>, VmError> {
+        vm.state.db.custom_handler.do_something_with_query(query);
+        Ok(SystemResult::Ok(CosmwasmQueryResult::Ok(vec![].into())))
+    }
+}
+
+pub type CustomJunoApi<'a, E = Dispatch> = Api<
+    'a,
+    E,
+    JunoAddressHandler,
+    State<MyCustomHandler, JunoAddressHandler>,
+    Context<'a, MyCustomHandler, JunoAddressHandler>,
+>;
+
+#[tokio::main]
+async fn main() {
+    let code = FileFetcher::from_url(REFLECT_URL).await.unwrap();
+    let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
+    let mut state = StateBuilder::<JunoAddressHandler, MyCustomHandler>::new()
+        .add_code(&code)
+        .set_custom_handler(MyCustomHandler {})
+        .build();
+    let _ = <CustomJunoApi>::instantiate_raw(
+        &mut state,
+        1,
+        None,
+        block(),
+        None,
+        info(&sender),
+        100_000_000,
+        r#"{}"#.as_bytes(),
+    )
+    .unwrap();
+}

--- a/orchestrate/examples/tests.rs
+++ b/orchestrate/examples/tests.rs
@@ -7,10 +7,7 @@ mod tests {
         vm::{Account, JunoAddressHandler, WasmAddressHandler},
         *,
     };
-    use cosmwasm_std::{
-        to_binary, BankMsg, BlockInfo, Coin, ContractInfo, ContractResult, CosmosMsg, Env,
-        MessageInfo, Timestamp,
-    };
+    use cosmwasm_std::{to_binary, BankMsg, Coin, ContractResult, CosmosMsg, MessageInfo};
     use cosmwasm_vm::executor::{CosmwasmQueryResult, QueryResult};
     use cw20::{BalanceResponse, Cw20Coin};
     use cw20_base::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};

--- a/orchestrate/examples/tests.rs
+++ b/orchestrate/examples/tests.rs
@@ -2,7 +2,11 @@
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_orchestrate::{fetcher::*, vm::Account, Api, Direct, StateBuilder};
+    use cosmwasm_orchestrate::{
+        fetcher::*,
+        vm::{Account, WasmAddressHandler},
+        Api, Direct, StateBuilder,
+    };
     use cosmwasm_std::{
         to_binary, BankMsg, BlockInfo, Coin, ContractInfo, ContractResult, CosmosMsg, Env,
         MessageInfo, Timestamp,
@@ -27,7 +31,7 @@ mod tests {
     async fn bank() {
         initialize();
         let code = FileFetcher::from_url(REFLECT_URL).await.unwrap();
-        let sender = Account::unchecked("sender");
+        let sender = Account::generate_from_seed::<WasmAddressHandler>("sender").unwrap();
         let mut state = StateBuilder::new()
             .add_code(&code)
             .add_balance(sender.clone(), Coin::new(10_000_000, "denom"))
@@ -111,7 +115,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let sender = Account::unchecked("sender");
+        let sender = Account::generate_from_seed::<WasmAddressHandler>("sender").unwrap();
 
         let mut state = StateBuilder::new().add_code(&code).build();
         let block = BlockInfo {
@@ -159,7 +163,9 @@ mod tests {
             info,
             100_000_000,
             ExecuteMsg::Transfer {
-                recipient: "receiver".into(),
+                recipient: Account::generate_from_seed::<WasmAddressHandler>("receiver")
+                    .unwrap()
+                    .into(),
                 amount: 10_000_u128.into(),
             },
         )
@@ -170,7 +176,9 @@ mod tests {
                 &mut state,
                 env,
                 &serde_json::to_vec(&QueryMsg::Balance {
-                    address: "receiver".into()
+                    address: Account::generate_from_seed::<WasmAddressHandler>("receiver")
+                        .unwrap()
+                        .into(),
                 })
                 .unwrap()
             )

--- a/orchestrate/examples/tests.rs
+++ b/orchestrate/examples/tests.rs
@@ -41,7 +41,7 @@ mod tests {
             sender: sender.clone().into(),
             funds: vec![Coin::new(400_000, "denom")],
         };
-        let (contract, _) = Api::instantiate_raw(
+        let (contract, _) = <Api>::instantiate_raw(
             &mut state,
             1,
             None,
@@ -74,7 +74,7 @@ mod tests {
         };
 
         info.funds = vec![];
-        let _ = Api::execute_raw(
+        let _ = <Api>::execute_raw(
             &mut state,
             env,
             info.clone(),
@@ -153,7 +153,7 @@ mod tests {
         };
         assert_matches!(res, ContractResult::Ok(_));
 
-        let _ = Api::execute(
+        let _ = <Api>::execute(
             &mut state,
             env.clone(),
             info,

--- a/orchestrate/src/api.rs
+++ b/orchestrate/src/api.rs
@@ -1,4 +1,4 @@
-use crate::vm::{Account, Context, IbcChannelId, State, VmError, VmState};
+use crate::vm::{Account, Context, IbcChannelId, State, VmError, VmState, WasmAddressHandler};
 use core::marker::PhantomData;
 use cosmwasm_std::{
     from_binary, Addr, Binary, BlockInfo, Coin, Empty, Env, Event, IbcChannelConnectMsg,
@@ -24,7 +24,7 @@ pub struct Api<
     'a,
     E: ExecutionType = Dispatch,
     S: VmState<'a, V> = State,
-    V: WasmiBaseVM = Context<'a, Empty>,
+    V: WasmiBaseVM = Context<'a, Empty, WasmAddressHandler>,
 > where
     VmErrorOf<WasmiVM<V>>: Into<VmError>,
 {

--- a/orchestrate/src/api.rs
+++ b/orchestrate/src/api.rs
@@ -23,6 +23,7 @@ use cosmwasm_vm::{
 use cosmwasm_vm_wasmi::{WasmiBaseVM, WasmiVM};
 use serde::{de::DeserializeOwned, Serialize};
 
+#[allow(clippy::module_name_repetitions)]
 pub type JunoApi<'a, E = Dispatch> = Api<
     'a,
     E,
@@ -31,6 +32,7 @@ pub type JunoApi<'a, E = Dispatch> = Api<
     Context<'a, (), JunoAddressHandler>,
 >;
 
+#[allow(clippy::module_name_repetitions)]
 pub type WasmApi<'a, E = Dispatch> = Api<
     'a,
     E,
@@ -39,6 +41,7 @@ pub type WasmApi<'a, E = Dispatch> = Api<
     Context<'a, (), WasmAddressHandler>,
 >;
 
+#[allow(clippy::module_name_repetitions)]
 pub type SubstrateApi<'a, E = Dispatch> = Api<
     'a,
     E,
@@ -475,7 +478,6 @@ impl ExecutionType for Dispatch {
 }
 
 /// Convenient builder for `State`
-#[derive(Default)]
 pub struct StateBuilder<AH: AddressHandler, CH: CustomHandler = ()> {
     codes: Vec<Vec<u8>>,
     balances: Vec<(Account, Coin)>,
@@ -484,10 +486,22 @@ pub struct StateBuilder<AH: AddressHandler, CH: CustomHandler = ()> {
     _marker: PhantomData<AH>,
 }
 
+impl<CH: CustomHandler + Default, AH: AddressHandler> Default for StateBuilder<AH, CH> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<CH: CustomHandler + Default, AH: AddressHandler> StateBuilder<AH, CH> {
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            codes: Vec::default(),
+            balances: Vec::default(),
+            ibc_channels: Vec::default(),
+            custom_handler: CH::default(),
+            _marker: PhantomData,
+        }
     }
 
     #[must_use]

--- a/orchestrate/src/api.rs
+++ b/orchestrate/src/api.rs
@@ -1,7 +1,7 @@
 use crate::vm::{Account, Context, IbcChannelId, State, VmError, VmState};
 use core::marker::PhantomData;
 use cosmwasm_std::{
-    from_binary, Addr, Binary, BlockInfo, Coin, Env, Event, IbcChannelConnectMsg,
+    from_binary, Addr, Binary, BlockInfo, Coin, Empty, Env, Event, IbcChannelConnectMsg,
     IbcChannelOpenMsg, IbcPacketAckMsg, IbcPacketReceiveMsg, IbcPacketTimeoutMsg, MessageInfo,
     TransactionInfo,
 };
@@ -24,7 +24,7 @@ pub struct Api<
     'a,
     E: ExecutionType = Dispatch,
     S: VmState<'a, V> = State,
-    V: WasmiBaseVM = Context<'a>,
+    V: WasmiBaseVM = Context<'a, Empty>,
 > where
     VmErrorOf<WasmiVM<V>>: Into<VmError>,
 {

--- a/orchestrate/src/api.rs
+++ b/orchestrate/src/api.rs
@@ -217,6 +217,75 @@ where
         Self::execute_raw(vm_state, env, info, gas, &message)
     }
 
+    /// Migrate a contract.
+    ///
+    /// * `vm_state`: Shared VM state.
+    /// * `env`: `Env` to be passed to contract.
+    /// * `info`: `MessageInfo` to be passed to contract.
+    /// * `gas`: Gas limit of this call.
+    /// * `message`: Raw JSON-encoded `ExecuteMsg`.
+    pub fn migrate_raw(
+        vm_state: &'a mut S,
+        code_id: CosmwasmCodeId,
+        env: Env,
+        info: MessageInfo,
+        gas: u64,
+        message: &[u8],
+    ) -> Result<E::Output<V>, VmError> {
+        vm_state.do_migrate::<E>(code_id, env, info, gas, message)
+    }
+
+    /// Migrate a contract.
+    ///
+    /// * `vm_state`: Shared VM state.
+    /// * `code_id`: Id of the code to migrate to.
+    /// * `env`: `Env` to be passed to contract.
+    /// * `info`: `MessageInfo` to be passed to contract.
+    /// * `gas`: Gas limit of this call.
+    /// * `message`: Typed message. Possibly `ExecuteMsg` from a contract.
+    pub fn migrate<M: Serialize>(
+        vm_state: &'a mut S,
+        code_id: CosmwasmCodeId,
+        env: Env,
+        info: MessageInfo,
+        gas: u64,
+        message: M,
+    ) -> Result<E::Output<V>, VmError> {
+        let message = serde_json::to_vec(&message).map_err(|_| VmError::CannotSerialize)?;
+        Self::migrate_raw(vm_state, code_id, env, info, gas, &message)
+    }
+
+    /// Update admin of a contract.
+    ///
+    /// * `vm_state`: Shared VM state.
+    /// * `sender`: Caller of this endpoint.
+    /// * `contract`: Contract to update admin.
+    /// * `new_admin`: New admin to update to.
+    pub fn update_admin(
+        vm_state: &'a mut S,
+        sender: &Account,
+        contract_addr: &Account,
+        new_admin: Account,
+        gas: u64,
+    ) -> Result<(), VmError> {
+        vm_state.do_update_admin(sender, contract_addr, Some(new_admin), gas)
+    }
+
+    /// Clear admin of a contract.
+    ///
+    /// * `vm_state`: Shared VM state.
+    /// * `sender`: Caller of this endpoint.
+    /// * `contract`: Contract to update admin.
+    /// * `new_admin`: New admin to update to.
+    pub fn clear_admin(
+        vm_state: &'a mut S,
+        sender: &Account,
+        contract_addr: &Account,
+        gas: u64,
+    ) -> Result<(), VmError> {
+        vm_state.do_update_admin(sender, contract_addr, None, gas)
+    }
+
     /// Initiate an IBC channel handshake.
     ///
     /// * `vm_state`: Shared VM state.

--- a/orchestrate/src/error.rs
+++ b/orchestrate/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     CannotDecode,
     CannotSerialize,
     CannotDeserialize,
+    CannotCompileWasm,
 }
 
 impl Display for Error {

--- a/orchestrate/src/ibc.rs
+++ b/orchestrate/src/ibc.rs
@@ -1,6 +1,6 @@
 use crate::{
-    vm::{Account, IbcState, State, VmError},
-    Api, Direct,
+    vm::{Account, AddressHandler, Context, CustomHandler, IbcState, State, VmError},
+    Api as IApi, Direct, Dispatch,
 };
 use cosmwasm_std::{
     Env, Ibc3ChannelOpenResponse, IbcAcknowledgement, IbcChannel, IbcChannelConnectMsg,
@@ -11,13 +11,15 @@ use cosmwasm_std::{
 pub type ConnectionId = String;
 
 #[allow(clippy::module_name_repetitions)]
-pub struct IbcNetwork<'a> {
-    pub state: &'a mut State,
-    pub state_counterparty: &'a mut State,
+pub struct IbcNetwork<'a, CH: CustomHandler, AH: AddressHandler> {
+    pub state: &'a mut State<CH, AH>,
+    pub state_counterparty: &'a mut State<CH, AH>,
 }
 
-impl<'a> IbcNetwork<'a> {
-    pub fn new(state: &'a mut State, state_counterparty: &'a mut State) -> IbcNetwork<'a> {
+type Api<'a, E, CH, AH> = IApi<'a, E, AH, State<CH, AH>, Context<'a, CH, AH>>;
+
+impl<'a, CH: CustomHandler, AH: AddressHandler> IbcNetwork<'a, CH, AH> {
+    pub fn new(state: &'a mut State<CH, AH>, state_counterparty: &'a mut State<CH, AH>) -> Self {
         IbcNetwork {
             state,
             state_counterparty,
@@ -43,11 +45,11 @@ impl<'a> IbcNetwork<'a> {
         gas: u64,
         a: &A,
         a_counterparty: &A,
-        mut pre: impl FnMut(&mut State, &mut State, &A, &A),
-        mut post: impl FnMut(&mut State, &mut State, &A, &A),
+        mut pre: impl FnMut(&mut State<CH, AH>, &mut State<CH, AH>, &A, &A),
+        mut post: impl FnMut(&mut State<CH, AH>, &mut State<CH, AH>, &A, &A),
     ) -> Result<(), VmError> {
         pre(self.state, self.state_counterparty, a, a_counterparty);
-        ibc_relay(
+        ibc_relay::<CH, AH>(
             &channel,
             self.state,
             self.state_counterparty,
@@ -60,7 +62,7 @@ impl<'a> IbcNetwork<'a> {
         post(self.state, self.state_counterparty, a, a_counterparty);
         let mut network_reversed = IbcNetwork::new(self.state_counterparty, self.state);
         if network_reversed.relay_required(&channel)? {
-            network_reversed.relay(
+            network_reversed.relay::<A>(
                 ibc_reverse_channel(channel),
                 env_counterparty,
                 env,
@@ -106,7 +108,7 @@ impl<'a> IbcNetwork<'a> {
         );
 
         // Step 1, OpenInit/Try
-        let override_version = Api::<Direct>::ibc_channel_open(
+        let override_version = Api::<Direct, CH, AH>::ibc_channel_open(
             self.state,
             env.clone(),
             info.clone(),
@@ -124,7 +126,7 @@ impl<'a> IbcNetwork<'a> {
             channel.version = version;
         }
 
-        let override_version_counterparty = Api::<Direct>::ibc_channel_open(
+        let override_version_counterparty = Api::<Direct, CH, AH>::ibc_channel_open(
             self.state_counterparty,
             env_counterparty.clone(),
             info_counterparty.clone(),
@@ -146,7 +148,7 @@ impl<'a> IbcNetwork<'a> {
         let channel_counterparty = ibc_reverse_channel(channel.clone());
 
         // Step 2, OpenAck/Confirm
-        let result = <Api>::ibc_channel_connect(
+        let result = Api::<Dispatch, CH, AH>::ibc_channel_connect(
             self.state,
             env,
             info,
@@ -157,7 +159,7 @@ impl<'a> IbcNetwork<'a> {
             },
         )?;
         log::debug!("Handshake: {:?}", result);
-        let result = <Api>::ibc_channel_connect(
+        let result = Api::<Dispatch, CH, AH>::ibc_channel_connect(
             self.state_counterparty,
             env_counterparty,
             info_counterparty,
@@ -195,7 +197,10 @@ pub fn ibc_reverse_channel(channel: IbcChannel) -> IbcChannel {
 }
 
 #[allow(clippy::module_name_repetitions)]
-pub fn ibc_relay_required(channel: &IbcChannel, state: &State) -> Result<bool, VmError> {
+pub fn ibc_relay_required<CH: CustomHandler, AH: AddressHandler>(
+    channel: &IbcChannel,
+    state: &State<CH, AH>,
+) -> Result<bool, VmError> {
     let channel_state = state
         .db
         .ibc
@@ -205,10 +210,10 @@ pub fn ibc_relay_required(channel: &IbcChannel, state: &State) -> Result<bool, V
 }
 
 #[allow(clippy::module_name_repetitions)]
-pub fn ibc_relay(
+pub fn ibc_relay<CH: CustomHandler, AH: AddressHandler>(
     channel: &IbcChannel,
-    state: &mut State,
-    state_counterparty: &mut State,
+    state: &mut State<CH, AH>,
+    state_counterparty: &mut State<CH, AH>,
     env: &Env,
     env_counterparty: &Env,
     info: &MessageInfo,
@@ -224,7 +229,7 @@ pub fn ibc_relay(
         .ok_or(VmError::UnknownIbcChannel)?;
     if channel_state.request_close {
         for packet in channel_state.packets.drain(0..).collect::<Vec<_>>() {
-            <Api>::ibc_packet_timeout(
+            Api::<Dispatch, CH, AH>::ibc_packet_timeout(
                 state,
                 env.clone(),
                 info.clone(),
@@ -245,7 +250,7 @@ pub fn ibc_relay(
         for packet in channel_state.packets.drain(0..).collect::<Vec<_>>() {
             log::info!("Relaying: {:?}", packet);
             // TODO: check timeout after env passed as parameter to Full methods
-            let (ack, _) = <Api>::ibc_packet_receive(
+            let (ack, _) = Api::<Dispatch, CH, AH>::ibc_packet_receive(
                 state_counterparty,
                 env_counterparty.clone(),
                 info_counterparty.clone(),
@@ -262,7 +267,7 @@ pub fn ibc_relay(
                 ),
             )?;
             log::info!("Packet ACK: {:?}", ack);
-            <Api>::ibc_packet_ack(
+            Api::<Dispatch, CH, AH>::ibc_packet_ack(
                 state,
                 env.clone(),
                 info.clone(),

--- a/orchestrate/src/ibc.rs
+++ b/orchestrate/src/ibc.rs
@@ -11,7 +11,7 @@ use cosmwasm_std::{
 pub type ConnectionId = String;
 
 #[allow(clippy::module_name_repetitions)]
-pub struct IbcNetwork<'a, CH: CustomHandler, AH: AddressHandler> {
+pub struct IbcNetwork<'a, CH, AH> {
     pub state: &'a mut State<CH, AH>,
     pub state_counterparty: &'a mut State<CH, AH>,
 }

--- a/orchestrate/src/lib.rs
+++ b/orchestrate/src/lib.rs
@@ -9,5 +9,8 @@ pub mod error;
 pub mod fetcher;
 pub mod ibc;
 pub mod vm;
+mod wasm_builder;
 
 pub use api::*;
+pub use cosmwasm_std;
+pub use wasm_builder::*;

--- a/orchestrate/src/vm/account.rs
+++ b/orchestrate/src/vm/account.rs
@@ -1,8 +1,6 @@
-use core::fmt::Display;
-
-use super::VmError;
-use alloc::format;
+use super::{AddressHandler, VmError};
 use alloc::vec::Vec;
+use core::fmt::Display;
 use cosmwasm_std::{Addr, Binary, CanonicalAddr};
 use sha1::{Digest, Sha1};
 
@@ -59,6 +57,12 @@ impl From<Account> for Addr {
     }
 }
 
+impl From<Account> for String {
+    fn from(account: Account) -> Self {
+        account.0.into_string()
+    }
+}
+
 impl Account {
     pub fn unchecked<A: Into<String>>(addr: A) -> Self {
         Account(Addr::unchecked(addr))
@@ -71,12 +75,9 @@ impl Account {
     ///
     /// The address is generated with the algorithm: `Sha1(code_hash + message)`
     #[must_use]
-    pub fn generate(code_hash: &[u8], message: &[u8]) -> Self {
-        let hash = Sha1::new()
-            .chain_update(code_hash)
-            .chain_update(message)
-            .finalize();
-        Account(Addr::unchecked(format!("{hash:x}")))
+    pub fn generate<AH: AddressHandler>(code_hash: &[u8], message: &[u8]) -> Result<Self, VmError> {
+        let addr = AH::addr_generate([code_hash, message])?;
+        Ok(Self::unchecked(addr))
     }
 
     /// Generates an `Account` based on `code` and `message`
@@ -90,8 +91,18 @@ impl Account {
     /// execution.
     /// See [`Self::generate`] for the generation algorithm
     #[must_use]
-    pub fn generate_by_code(code: &[u8], message: &[u8]) -> Self {
+    pub fn generate_by_code<AH: AddressHandler>(
+        code: &[u8],
+        message: &[u8],
+    ) -> Result<Self, VmError> {
         let code_hash = Sha1::new().chain_update(code).finalize();
-        Self::generate(&code_hash[..], message)
+        Self::generate::<AH>(&code_hash[..], message)
+    }
+
+    /// Generates an `Account` based on the provided `seed`
+    #[must_use]
+    pub fn generate_from_seed<AH: AddressHandler>(seed: &str) -> Result<Self, VmError> {
+        let addr = AH::addr_generate([seed.as_ref()])?;
+        Ok(Self::unchecked(addr))
     }
 }

--- a/orchestrate/src/vm/account.rs
+++ b/orchestrate/src/vm/account.rs
@@ -74,7 +74,6 @@ impl Account {
     /// * `message` - Raw instantiate message
     ///
     /// The address is generated with the algorithm: `Sha1(code_hash + message)`
-    #[must_use]
     pub fn generate<AH: AddressHandler>(code_hash: &[u8], message: &[u8]) -> Result<Self, VmError> {
         let addr = AH::addr_generate([code_hash, message])?;
         Ok(Self::unchecked(addr))
@@ -90,7 +89,6 @@ impl Account {
     /// that by using this function, one can generate the `Account` prior to
     /// execution.
     /// See [`Self::generate`] for the generation algorithm
-    #[must_use]
     pub fn generate_by_code<AH: AddressHandler>(
         code: &[u8],
         message: &[u8],
@@ -100,7 +98,6 @@ impl Account {
     }
 
     /// Generates an `Account` based on the provided `seed`
-    #[must_use]
     pub fn generate_from_seed<AH: AddressHandler>(seed: &str) -> Result<Self, VmError> {
         let addr = AH::addr_generate([seed.as_ref()])?;
         Ok(Self::unchecked(addr))

--- a/orchestrate/src/vm/account.rs
+++ b/orchestrate/src/vm/account.rs
@@ -2,7 +2,7 @@ use super::{AddressHandler, VmError};
 use alloc::vec::Vec;
 use core::fmt::Display;
 use cosmwasm_std::{Addr, Binary, CanonicalAddr};
-use sha1::{Digest, Sha1};
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone)]
 #[allow(clippy::module_name_repetitions)]
@@ -95,7 +95,7 @@ impl Account {
         code: &[u8],
         message: &[u8],
     ) -> Result<Self, VmError> {
-        let code_hash = Sha1::new().chain_update(code).finalize();
+        let code_hash = Sha256::new().chain_update(code).finalize();
         Self::generate::<AH>(&code_hash[..], message)
     }
 

--- a/orchestrate/src/vm/address.rs
+++ b/orchestrate/src/vm/address.rs
@@ -1,0 +1,110 @@
+use super::VmError;
+use bech32::{self, FromBase32, ToBase32, Variant};
+use cosmwasm_std::CanonicalAddr;
+use cosmwasm_vm::vm::{VmAddressOf, VmCanonicalAddressOf, VmErrorOf};
+use cosmwasm_vm_wasmi::WasmiBaseVM;
+
+pub trait AddressHandler {
+    fn addr_validate<V: WasmiBaseVM>(input: &str) -> Result<(), VmErrorOf<V>>
+    where
+        VmErrorOf<V>: From<VmError>,
+    {
+        let canonical_addr = Self::addr_canonicalize::<V>(input)?;
+        let addr = Self::addr_humanize::<V>(&canonical_addr)?;
+        if addr.into().as_ref() == input {
+            Ok(())
+        } else {
+            Err(VmError::InvalidAddress.into())
+        }
+    }
+
+    fn addr_canonicalize<V: WasmiBaseVM>(
+        input: &str,
+    ) -> Result<VmCanonicalAddressOf<V>, VmErrorOf<V>>
+    where
+        VmErrorOf<V>: From<VmError>;
+
+    fn addr_humanize<V: WasmiBaseVM>(
+        addr: &VmCanonicalAddressOf<V>,
+    ) -> Result<VmAddressOf<V>, VmErrorOf<V>>
+    where
+        VmErrorOf<V>: From<VmError>;
+}
+
+pub trait CosmosAddressHandler {
+    const PREFIX: &'static str;
+}
+
+impl<T: CosmosAddressHandler> AddressHandler for T {
+    fn addr_canonicalize<V: WasmiBaseVM>(
+        input: &str,
+    ) -> Result<VmCanonicalAddressOf<V>, VmErrorOf<V>>
+    where
+        VmErrorOf<V>: From<VmError>,
+    {
+        // TODO(aeryz): check if we need to check if the data size is 20 or 32.
+        // We don't care about the data part. As long as it is a valid bech32, it's fine.
+        let (hrp, data, _) = bech32::decode(input).map_err(|_| VmError::DecodingFailure)?;
+        let data = Vec::<u8>::from_base32(&data).map_err(|_| VmError::InvalidAddress)?;
+
+        if hrp != T::PREFIX {
+            return Err(VmError::InvalidAddress.into());
+        }
+
+        data.try_into()
+    }
+
+    fn addr_humanize<V: WasmiBaseVM>(
+        addr: &VmCanonicalAddressOf<V>,
+    ) -> Result<VmAddressOf<V>, VmErrorOf<V>>
+    where
+        VmErrorOf<V>: From<VmError>,
+    {
+        let canonical_addr: CanonicalAddr = addr.clone().into();
+        bech32::encode(
+            Self::PREFIX,
+            Into::<Vec<u8>>::into(canonical_addr).to_base32(),
+            Variant::Bech32,
+        )
+        .map_err(|_| VmError::EncodingFailure)?
+        .try_into()
+    }
+}
+
+pub struct JunoAddrHandler;
+
+impl CosmosAddressHandler for JunoAddrHandler {
+    const PREFIX: &'static str = "juno";
+}
+
+pub struct WasmAddressHandler;
+
+impl CosmosAddressHandler for WasmAddressHandler {
+    const PREFIX: &'static str = "wasm";
+}
+
+pub struct SubstrateAddressHandler;
+
+impl AddressHandler for SubstrateAddressHandler {
+    fn addr_canonicalize<V: WasmiBaseVM>(
+        input: &str,
+    ) -> Result<VmCanonicalAddressOf<V>, VmErrorOf<V>>
+    where
+        VmErrorOf<V>: From<VmError>,
+    {
+        bs58::decode(input)
+            .into_vec()
+            .map_err(|_| VmError::DecodingFailure)?
+            .try_into()
+    }
+
+    fn addr_humanize<V: WasmiBaseVM>(
+        addr: &VmCanonicalAddressOf<V>,
+    ) -> Result<VmAddressOf<V>, VmErrorOf<V>>
+    where
+        VmErrorOf<V>: From<VmError>,
+    {
+        let addr: Vec<u8> = Into::<CanonicalAddr>::into(addr.clone()).into();
+        bs58::encode(&addr).into_string().try_into()
+    }
+}

--- a/orchestrate/src/vm/address.rs
+++ b/orchestrate/src/vm/address.rs
@@ -8,6 +8,7 @@ const COSMOS_ADDR_LEN: usize = 20;
 const COSMOS_ADDR_LEN_2: usize = 32;
 const SUBSTRATE_ADDR_LEN: usize = 32;
 
+#[allow(clippy::module_name_repetitions)]
 pub trait AddressHandler {
     fn addr_validate(input: &str) -> Result<(), VmError> {
         let canonical_addr = Self::addr_canonicalize(input)?;

--- a/orchestrate/src/vm/error.rs
+++ b/orchestrate/src/vm/error.rs
@@ -32,6 +32,8 @@ pub enum VmError {
     UnknownIbcChannel,
     IbcChannelOpenFailure(String),
     Generic(String),
+    EncodingFailure,
+    DecodingFailure,
 }
 
 impl From<wasmi::Error> for VmError {

--- a/orchestrate/src/vm/error.rs
+++ b/orchestrate/src/vm/error.rs
@@ -34,6 +34,7 @@ pub enum VmError {
     Generic(String),
     EncodingFailure,
     DecodingFailure,
+    NotAuthorized,
 }
 
 impl From<wasmi::Error> for VmError {

--- a/orchestrate/src/vm/mod.rs
+++ b/orchestrate/src/vm/mod.rs
@@ -95,7 +95,7 @@ impl Gas {
 pub type QueryCustomOf<T> = <T as CustomHandler>::QueryCustom;
 pub type MessageCustomOf<T> = <T as CustomHandler>::MessageCustom;
 
-pub trait CustomHandler: Sized {
+pub trait CustomHandler: Sized + Clone + Default {
     type QueryCustom: DeserializeOwned + Debug;
     type MessageCustom: DeserializeOwned + Debug;
 
@@ -174,14 +174,15 @@ impl IbcState {
 pub type IbcChannelId = String;
 
 #[derive(Default, Clone)]
-pub struct Db {
+pub struct Db<CH> {
     pub ibc: BTreeMap<IbcChannelId, IbcState>,
     pub contracts: BTreeMap<Account, CosmwasmContractMeta<Account>>,
     pub storage: BTreeMap<Account, Storage>,
     pub bank: Bank,
+    pub custom_handler: CH,
 }
 
-impl Debug for Db {
+impl<CH: CustomHandler> Debug for Db<CH> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Db")
             .field("ibc", &self.ibc)

--- a/orchestrate/src/vm/mod.rs
+++ b/orchestrate/src/vm/mod.rs
@@ -100,45 +100,35 @@ pub trait CustomHandler {
     type QueryCustom: DeserializeOwned + Debug;
     type MessageCustom: DeserializeOwned + Debug;
 
-    fn handle_message<V: VMBase>(
-        vm: &mut V,
+    fn handle_message<CH: CustomHandler, AH: AddressHandler>(
+        vm: &mut Context<CH, AH>,
         message: Self::MessageCustom,
         event_handler: &mut dyn FnMut(Event),
-    ) -> Result<Option<Binary>, VmErrorOf<V>>
-    where
-        for<'x> VmErrorOf<V>: From<VmError>;
+    ) -> Result<Option<Binary>, VmError>;
 
-    fn handle_query<V: VMBase>(
-        vm: &mut V,
+    fn handle_query<CH: CustomHandler, AH: AddressHandler>(
+        vm: &mut Context<CH, AH>,
         query: Self::QueryCustom,
-    ) -> Result<SystemResult<CosmwasmQueryResult>, VmErrorOf<V>>
-    where
-        for<'x> VmErrorOf<V>: From<VmError>;
+    ) -> Result<SystemResult<CosmwasmQueryResult>, VmError>;
 }
 
 impl CustomHandler for Empty {
     type QueryCustom = Empty;
     type MessageCustom = Empty;
 
-    fn handle_message<V: VMBase>(
-        _: &mut V,
+    fn handle_message<CH: CustomHandler, AH: AddressHandler>(
+        _: &mut Context<CH, AH>,
         _: Self::MessageCustom,
         _: &mut dyn FnMut(Event),
-    ) -> Result<Option<Binary>, VmErrorOf<V>>
-    where
-        for<'x> VmErrorOf<V>: From<VmError>,
-    {
-        Err(VmError::NoCustomMessage.into())
+    ) -> Result<Option<Binary>, VmError> {
+        Err(VmError::NoCustomMessage)
     }
 
-    fn handle_query<V: VMBase>(
-        _: &mut V,
+    fn handle_query<CH: CustomHandler, AH: AddressHandler>(
+        _: &mut Context<CH, AH>,
         _: Self::QueryCustom,
-    ) -> Result<SystemResult<CosmwasmQueryResult>, VmErrorOf<V>>
-    where
-        for<'x> VmErrorOf<V>: From<VmError>,
-    {
-        Err(VmError::NoCustomQuery.into())
+    ) -> Result<SystemResult<CosmwasmQueryResult>, VmError> {
+        Err(VmError::NoCustomQuery)
     }
 }
 

--- a/orchestrate/src/vm/state.rs
+++ b/orchestrate/src/vm/state.rs
@@ -233,7 +233,7 @@ where
             block: BlockInfo {
                 height: 0,
                 time: Timestamp::from_seconds(1),
-                chain_id: "".into(),
+                chain_id: String::new(),
             },
             transaction: None,
             contract: ContractInfo {

--- a/orchestrate/src/vm/state.rs
+++ b/orchestrate/src/vm/state.rs
@@ -89,16 +89,16 @@ where
 }
 
 #[derive(Clone)]
-pub struct State<CH: CustomHandler, AH: AddressHandler> {
-    pub transactions: VecDeque<Db>,
-    pub db: Db,
+pub struct State<CH, AH> {
+    pub transactions: VecDeque<Db<CH>>,
+    pub db: Db<CH>,
     pub codes: BTreeMap<CosmwasmCodeId, (Vec<u8>, Vec<u8>)>,
     pub gas: Gas,
-    pub custom_handler: CH,
     _marker: PhantomData<AH>,
 }
 
-impl<'a, CH: CustomHandler, AH: AddressHandler> VmState<'a, Context<'a, CH, AH>> for State<CH, AH>
+impl<'a, CH: CustomHandler + Clone, AH: AddressHandler> VmState<'a, Context<'a, CH, AH>>
+    for State<CH, AH>
 where
     VmErrorOf<WasmiVM<Context<'a, CH, AH>>>: Into<VmError>,
 {
@@ -278,10 +278,10 @@ impl<CH: CustomHandler, AH: AddressHandler> State<CH, AH> {
                     .into_iter()
                     .map(|x| (x, IbcState::default()))
                     .collect(),
+                custom_handler,
                 ..Default::default()
             },
             transactions: VecDeque::default(),
-            custom_handler,
             _marker: PhantomData,
         }
     }

--- a/orchestrate/src/vm/state.rs
+++ b/orchestrate/src/vm/state.rs
@@ -118,7 +118,7 @@ where
                 .codes
                 .get(&code_id)
                 .ok_or(VmError::CodeNotFound(code_id))?;
-            Account::generate(code_hash, message)
+            Account::generate::<AH>(code_hash, message)?
         };
         self.gas = Gas::new(gas);
         if self.db.contracts.contains_key(&contract_addr) {

--- a/orchestrate/src/wasm_builder.rs
+++ b/orchestrate/src/wasm_builder.rs
@@ -1,0 +1,90 @@
+use super::error::Error;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Compile contracts to `wasm` binaries.
+/// This is meant to be used prior to the test execution. Otherwise, the users
+/// would need to compile their contracts everytime they change it.
+pub struct WasmLoader {
+    package_name: String,
+    contract_name: String,
+    binary_path: String,
+    compile_command: Option<Command>,
+}
+
+/// Default output directory of the `wasm` binary.
+const DEFAULT_WASM_BINARY_PATH: &str = "target/wasm32-unknown-unknown/release";
+
+impl WasmLoader {
+    #[must_use]
+    pub fn new<S: Into<String> + Clone>(package_name: S) -> Self {
+        Self {
+            package_name: package_name.clone().into(),
+            contract_name: package_name.into(),
+            binary_path: DEFAULT_WASM_BINARY_PATH.into(),
+            compile_command: None,
+        }
+    }
+
+    /// Set the package name to be compiled.
+    /// This will be given to as value to `--package`. (If the default compilation command is used)
+    #[must_use]
+    pub fn package<S: Into<String>>(mut self, package_name: S) -> Self {
+        self.package_name = package_name.into();
+        self
+    }
+
+    /// Set the contract name to be read.
+    /// This will be used to get the compiled wasm binary from the path: `{binary_path}/{contract_name}.wasm`
+    #[must_use]
+    pub fn contract<S: Into<String>>(mut self, contract_name: S) -> Self {
+        self.contract_name = contract_name.into();
+        self
+    }
+
+    /// Set the compilation command to be executed.
+    /// This will be executed to compile the desired contract.
+    #[must_use]
+    pub fn command(mut self, compile_command: Command) -> Self {
+        self.compile_command = Some(compile_command);
+        self
+    }
+
+    /// Set the path to the output `wasm` binary.
+    /// This will be used to get the compiled wasm binary from the path: `{binary_path}/{contract_name}.wasm`
+    #[must_use]
+    pub fn binary_path<S: Into<String>>(mut self, path: S) -> Self {
+        self.binary_path = path.into();
+        self
+    }
+
+    /// Compile and load the `wasm` binary.
+    pub fn load(self) -> Result<Vec<u8>, Error> {
+        let mut default_command = Command::new("cargo");
+        let _ = default_command.args([
+            "build",
+            "--release",
+            "--target",
+            "wasm32-unknown-unknown",
+            "--package",
+            &self.package_name,
+        ]);
+
+        let mut command = self.compile_command.unwrap_or(default_command);
+
+        if !command
+            .status()
+            .map_err(|_| Error::CannotCompileWasm)?
+            .success()
+        {
+            return Err(Error::CannotCompileWasm);
+        }
+
+        fs::read(Path::new(&format!(
+            "{}/{}.wasm",
+            self.binary_path, self.contract_name
+        )))
+        .map_err(|_| Error::CannotCompileWasm)
+    }
+}

--- a/orchestrate/tests/crypto_verify.rs
+++ b/orchestrate/tests/crypto_verify.rs
@@ -1,6 +1,6 @@
 use cosmwasm_orchestrate::{
-    vm::{Account, State},
-    Api, Direct, StateBuilder,
+    vm::{Account, State, WasmAddressHandler},
+    Direct, StateBuilder, WasmApi as Api,
 };
 use cosmwasm_std::{from_binary, Binary, BlockInfo, ContractInfo, Env, MessageInfo, Timestamp};
 use serde::{Deserialize, Serialize};
@@ -54,7 +54,7 @@ fn message_info(sender: &Account) -> MessageInfo {
     }
 }
 
-fn setup() -> (Account, State) {
+fn setup() -> (Account, State<(), WasmAddressHandler>) {
     let wasm_code = include_bytes!("../../fixtures/crypto_verify.wasm");
     let mut state = StateBuilder::new().add_code(wasm_code).build();
 


### PR DESCRIPTION
With the CustomHandler extension, users will be able to add their custom logic to the VM without having to implement a new VM.